### PR TITLE
Feature mesh source

### DIFF
--- a/examples/mesh_example.py
+++ b/examples/mesh_example.py
@@ -1,0 +1,57 @@
+from numpy import array
+from mayavi.scripts import mayavi2
+
+from simphony.cuds.mesh import Mesh, Point, Cell, Edge, Face
+
+points = array([
+    [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+    [2, 0, 0], [3, 0, 0], [3, 1, 0], [2, 1, 0],
+    [2, 0, 1], [3, 0, 1], [3, 1, 1], [2, 1, 1]],
+    'f')
+
+cells = [
+    [0, 1, 2, 3],  # tetra
+    [4, 5, 6, 7, 8, 9, 10, 11]]  # hex
+
+faces = [[2, 7, 11]]
+edges = [[1, 4], [3, 8]]
+
+container = Mesh('test')
+
+# add points
+uids = [
+    container.add_point(Point(coordinates=point)) for point in points]
+
+# add edges
+edge_uids = [
+    container.add_edge(
+        Edge(points=[uids[index] for index in element]))
+    for element in edges]
+
+# add faces
+face_uids = [
+    container.add_face(
+        Face(points=[uids[index] for index in element]))
+    for element in faces]
+
+# add cells
+cell_uids = [
+    container.add_cell(
+        Cell(points=[uids[index] for index in element]))
+    for element in cells]
+
+
+# Now view the data.
+@mayavi2.standalone
+def view():
+    from mayavi.modules.surface import Surface
+    from simphony_mayavi.sources.api import MeshSource
+
+    mayavi.new_scene()  # noqa
+    src = MeshSource.from_mesh(container)
+    mayavi.add_source(src)  # noqa
+    s = Surface()
+    mayavi.add_module(s)  # noqa
+
+if __name__ == '__main__':
+    view()

--- a/simphony_mayavi/sources/api.py
+++ b/simphony_mayavi/sources/api.py
@@ -1,8 +1,10 @@
 from .particles_source import ParticlesSource
 from .lattice_source import LatticeSource
+from .mesh_source import MeshSource
 from .utils import cell_array_slicer
 
 __all__ = [
     'ParticlesSource',
     'LatticeSource',
+    'MeshSource',
     'cell_array_slicer']

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -27,7 +27,7 @@ EDGE2VTKCELL = defaultdict(
 
 
 class MeshSource(VTKDataSource):
-    """ A Mayavi Source wrapping a SimPhoNy CUDS Particle container.
+    """ A Mayavi Source wrapping a SimPhoNy CUDS Mesh container.
 
     """
 

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -31,10 +31,10 @@ class MeshSource(VTKDataSource):
 
     """
 
-    #: The mapping from the point uid to the vtk polydata points array.
+    #: The mapping from the point uid to the vtk points array.
     point2index = Dict
 
-    #: The mapping from the element uid to the vtk polydata cell index.
+    #: The mapping from the element uid to the vtk cell index.
     element2index = Dict
 
     @classmethod

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -87,7 +87,8 @@ def gather_cells(iterable, vtk_mapping, point2index, counter):
         The mapping from points uid to the index of the vtk points array.
 
     index : itertools.count
-        The counter object to use when evaluating the ``elements2index`` mapping.
+        The counter object to use when evaluating the ``elements2index``
+        mapping.
 
     Returns
     -------

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -69,6 +69,7 @@ class MeshSource(VTKDataSource):
         cell_array.set_cells(len(cell_offset), elements)
         data = tvtk.UnstructuredGrid(points=points)
         data.set_cells(element_types, cell_offset, cell_array)
+
         return cls(
             data=data,
             point2index=point2index,

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -1,0 +1,81 @@
+from collections import defaultdict
+
+import numpy
+
+from mayavi.sources.vtk_data_source import VTKDataSource
+from tvtk.api import tvtk
+from traits.api import Dict
+
+CELL2VTKCELL = {
+    4: tvtk.Tetra().cell_type,
+    8: tvtk.Hexahedron().cell_type,
+    6: tvtk.Wedge().cell_type,
+    5: tvtk.Pyramid().cell_type,
+    10: tvtk.PentagonalPrism().cell_type,
+    12: tvtk.HexagonalPrism().cell_type}
+
+FACE2VTKCELL = defaultdict(
+    lambda: tvtk.Polygon().cell_type,
+    {3: tvtk.Triangle().cell_type, 4: tvtk.Quad().cell_type})
+
+EDGE2VTKCELL = defaultdict(
+    lambda: tvtk.PolyLine().cell_type, {2: tvtk.Line().cell_type})
+
+
+class MeshSource(VTKDataSource):
+    """ A Mayavi Source wrapping a SimPhoNy CUDS Particle container.
+
+    """
+
+    #: The mapping from the point uid to the vtk polydata points array.
+    point2index = Dict
+
+    #: The mapping from the element uid to the vtk polydata cell index.
+    element2index = Dict
+
+    @classmethod
+    def from_mesh(cls, mesh):
+        points = []
+        point2index = {}
+        element2index = {}
+        for index, point in enumerate(mesh.iter_points()):
+            point2index[point.uid] = index
+            points.append(point.coordinates)
+
+        cells = []
+        cells_size = [0]
+        cell_types = []
+
+        for index, edge in enumerate(mesh.iter_edges()):
+            element2index[edge.uid] = index
+            npoints = len(edge.points)
+            cells_size.append(npoints + 1)
+            cells.append(npoints)
+            cells.extend(point2index[uid] for uid in edge.points)
+            cell_types.append(EDGE2VTKCELL[npoints])
+
+        for index, face in enumerate(mesh.iter_faces()):
+            element2index[face.uid] = index
+            npoints = len(face.points)
+            cells_size.append(npoints + 1)
+            cells.append(npoints)
+            cells.extend(point2index[uid] for uid in face.points)
+            cell_types.append(FACE2VTKCELL[npoints])
+
+        for index, cell in enumerate(mesh.iter_cells()):
+            element2index[cell.uid] = index
+            npoints = len(cell.points)
+            cells_size.append(npoints + 1)
+            cells.append(npoints)
+            cells.extend(point2index[uid] for uid in cell.points)
+            cell_types.append(CELL2VTKCELL[npoints])
+
+        offset = numpy.cumsum(cells_size[:-1])
+        cell_array = tvtk.CellArray()
+        cell_array.set_cells(len(offset), cells)
+        data = tvtk.UnstructuredGrid(points=points)
+        data.set_cells(cell_types, offset, cell_array)
+        return cls(
+            data=data,
+            point2index=point2index,
+            element2index=element2index)

--- a/simphony_mayavi/sources/mesh_source.py
+++ b/simphony_mayavi/sources/mesh_source.py
@@ -15,12 +15,15 @@ CELL2VTKCELL = {
     10: tvtk.PentagonalPrism().cell_type,
     12: tvtk.HexagonalPrism().cell_type}
 
+_polygon_type = tvtk.Polygon().cell_type
+_polyline_type = tvtk.PolyLine().cell_type
+
 FACE2VTKCELL = defaultdict(
-    lambda: tvtk.Polygon().cell_type,
+    lambda: _polygon_type,
     {3: tvtk.Triangle().cell_type, 4: tvtk.Quad().cell_type})
 
 EDGE2VTKCELL = defaultdict(
-    lambda: tvtk.PolyLine().cell_type, {2: tvtk.Line().cell_type})
+    lambda: _polyline_type, {2: tvtk.Line().cell_type})
 
 
 class MeshSource(VTKDataSource):

--- a/simphony_mayavi/sources/tests/test_mesh_source.py
+++ b/simphony_mayavi/sources/tests/test_mesh_source.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 from numpy.testing import assert_array_equal
 
-
 from simphony.cuds.mesh import Mesh, Point, Cell, Edge, Face
 from simphony_mayavi.sources.api import MeshSource, cell_array_slicer
 from simphony_mayavi.sources.mesh_source import (

--- a/simphony_mayavi/sources/tests/test_mesh_source.py
+++ b/simphony_mayavi/sources/tests/test_mesh_source.py
@@ -1,0 +1,102 @@
+import unittest
+
+import numpy
+from numpy.testing import assert_array_equal
+
+from simphony.cuds.mesh import Mesh, Point, Cell, Edge, Face
+from simphony_mayavi.sources.api import MeshSource, cell_array_slicer
+
+
+class TestParticlesSource(unittest.TestCase):
+
+    def setUp(self):
+        self.points = points = numpy.array([
+            [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+            [2, 0, 0], [3, 0, 0], [3, 1, 0], [2, 1, 0],
+            [2, 0, 1], [3, 0, 1], [3, 1, 1], [2, 1, 1]],
+            'f')
+
+        self.cells = [
+            [0, 1, 2, 3],  # tetra
+            [4, 5, 6, 7, 8, 9, 10, 11]]  # hex
+        self.faces = [[2, 7, 11]]
+        self.edges = [[1, 4], [3, 8]]
+        self.container = container = Mesh('test')
+        self.point_uids = [
+            container.add_point(Point(coordinates=point)) for point in points]
+
+    def test_points(self):
+        container = self.container
+        source = MeshSource.from_mesh(container)
+        points = source.data.points.to_array()
+
+        number_of_points = len(self.points)
+        self.assertEqual(len(points), number_of_points)
+        self.assertEqual(len(source.point2index), number_of_points)
+
+        for key, index in source.point2index.iteritems():
+            point = container.get_point(key)
+            assert_array_equal(points[index], point.coordinates)
+
+    def test_cells(self):
+        container = self.container
+        for cell in self.cells:
+            container.add_cell(
+                Cell(points=[self.point_uids[index] for index in cell]))
+
+        source = MeshSource.from_mesh(container)
+        vtk_source = source.data
+        cells = [
+            cell
+            for cell in cell_array_slicer(vtk_source.get_cells().to_array())]
+
+        number_of_cells = len(self.cells)
+        self.assertEqual(len(cells), number_of_cells)
+        self.assertEqual(len(source.element2index), number_of_cells)
+
+        for key, index in source.element2index.iteritems():
+            cell = container.get_cell(key)
+            points = [source.point2index[uid] for uid in cell.points]
+            self.assertEqual(cells[index], points)
+
+    def test_edges(self):
+        container = self.container
+        for edge in self.edges:
+            container.add_edge(
+                Edge(points=[self.point_uids[index] for index in edge]))
+
+        source = MeshSource.from_mesh(container)
+        vtk_source = source.data
+        edges = [
+            edge
+            for edge in cell_array_slicer(vtk_source.get_cells().to_array())]
+
+        number_of_edges = len(self.edges)
+        self.assertEqual(len(edges), number_of_edges)
+        self.assertEqual(len(source.element2index), number_of_edges)
+
+        for key, index in source.element2index.iteritems():
+            edge = container.get_edge(key)
+            points = [source.point2index[uid] for uid in edge.points]
+            self.assertEqual(edges[index], points)
+
+    def test_face(self):
+        container = self.container
+        for face in self.faces:
+            container.add_face(
+                Face(points=[self.point_uids[index] for index in face]))
+
+        source = MeshSource.from_mesh(container)
+        vtk_source = source.data
+        faces = [
+            face
+            for face in cell_array_slicer(vtk_source.get_cells().to_array())]
+
+        number_of_faces = len(self.faces)
+        self.assertEqual(len(faces), number_of_faces)
+        self.assertEqual(len(source.element2index), number_of_faces)
+
+        for key, index in source.element2index.iteritems():
+            face = container.get_face(key)
+            points = [source.point2index[uid] for uid in face.points]
+            self.assertEqual(faces[index], points)

--- a/simphony_mayavi/sources/tests/test_mesh_source.py
+++ b/simphony_mayavi/sources/tests/test_mesh_source.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy
 from numpy.testing import assert_array_equal
-from tvtk.api import tvtk
 
 
 from simphony.cuds.mesh import Mesh, Point, Cell, Edge, Face

--- a/simphony_mayavi/sources/tests/test_mesh_source.py
+++ b/simphony_mayavi/sources/tests/test_mesh_source.py
@@ -2,6 +2,8 @@ import unittest
 
 import numpy
 from numpy.testing import assert_array_equal
+from tvtk.api import tvtk
+
 
 from simphony.cuds.mesh import Mesh, Point, Cell, Edge, Face
 from simphony_mayavi.sources.api import MeshSource, cell_array_slicer
@@ -58,6 +60,9 @@ class TestParticlesSource(unittest.TestCase):
 
         for key, index in source.element2index.iteritems():
             cell = container.get_cell(key)
+            self.assertEqual(
+                vtk_source.get_cell_type(index),
+                CELL2VTKCELL[len(cell.points)])
             points = [source.point2index[uid] for uid in cell.points]
             self.assertEqual(cells[index], points)
 
@@ -79,6 +84,9 @@ class TestParticlesSource(unittest.TestCase):
 
         for key, index in source.element2index.iteritems():
             edge = container.get_edge(key)
+            self.assertEqual(
+                vtk_source.get_cell_type(index),
+                EDGE2VTKCELL[len(edge.points)])
             points = [source.point2index[uid] for uid in edge.points]
             self.assertEqual(edges[index], points)
 
@@ -100,10 +108,13 @@ class TestParticlesSource(unittest.TestCase):
 
         for key, index in source.element2index.iteritems():
             face = container.get_face(key)
+            self.assertEqual(
+                vtk_source.get_cell_type(index),
+                FACE2VTKCELL[len(face.points)])
             points = [source.point2index[uid] for uid in face.points]
             self.assertEqual(faces[index], points)
 
-    def test_all(self):
+    def test_all_element_types(self):
         container = self.container
         for face in self.faces:
             container.add_face(
@@ -130,10 +141,16 @@ class TestParticlesSource(unittest.TestCase):
             cell_type = vtk_source.get_cell_type(index)
             if cell_type in EDGE2VTKCELL.values():
                 element = container.get_edge(key)
+                self.assertEqual(
+                    cell_type, EDGE2VTKCELL[len(element.points)])
             elif cell_type in FACE2VTKCELL.values():
                 element = container.get_face(key)
+                self.assertEqual(
+                    cell_type, FACE2VTKCELL[len(element.points)])
             elif cell_type in CELL2VTKCELL.values():
                 element = container.get_cell(key)
+                self.assertEqual(
+                    cell_type, CELL2VTKCELL[len(element.points)])
             else:
                 self.fail('vtk source has an unknown cell type')
             points = [source.point2index[uid] for uid in element.points]


### PR DESCRIPTION
This PR adds a basic MeshSource that converts a SimPhoNy mesh into a mayavi source

![image](https://cloud.githubusercontent.com/assets/403930/6628139/023d0a20-c8fb-11e4-9ac8-eef6680f9912.png)

running the `mesh_example.py` file
