### PR TITLE
Support properties in lattice source

### DIFF
--- a/examples/lattice_example.py
+++ b/examples/lattice_example.py
@@ -1,22 +1,30 @@
-from mayavi.scripts import mayavi2
+import numpy
 
-from simphony.cuds.lattice import make_hexagonal_lattice
+from mayavi.scripts import mayavi2
+from simphony.cuds.lattice import (
+    make_hexagonal_lattice, make_cubic_lattice, make_square_lattice)
 from simphony.core.cuba import CUBA
 
-lattice = make_hexagonal_lattice('test', 0.1, (5, 4))
+hexagonal = make_hexagonal_lattice('test', 0.1, (5, 4))
+square = make_square_lattice('test', 0.1, (5, 4))
+cubic = make_cubic_lattice('test', 0.1, (2, 3, 4))
 
-temperature = 0.2
-for node in lattice.iter_nodes():
-    node.data[CUBA.TEMPERATURE] = temperature
-    lattice.update_node(node)
-    temperature += 0.2
+
+def add_temperature(lattice):
+    for node in lattice.iter_nodes():
+        index = numpy.array(node.index) + 1.0
+        node.data[CUBA.TEMPERATURE] = numpy.prod(index)
+        lattice.update_node(node)
+
+add_temperature(hexagonal)
+add_temperature(cubic)
+add_temperature(square)
 
 # Now view the data.
 @mayavi2.standalone
-def view():
+def view(lattice):
     from mayavi.modules.glyph import Glyph
     from simphony_mayavi.sources.api import LatticeSource
-
     mayavi.new_scene()  # noqa
     src = LatticeSource.from_lattice(lattice)
     mayavi.add_source(src)  # noqa
@@ -28,4 +36,4 @@ def view():
     mayavi.add_module(g)  # noqa
 
 if __name__ == '__main__':
-    view()
+    view(cubic)

--- a/examples/lattice_example.py
+++ b/examples/lattice_example.py
@@ -1,10 +1,15 @@
 from mayavi.scripts import mayavi2
 
 from simphony.cuds.lattice import make_hexagonal_lattice
-
+from simphony.core.cuba import CUBA
 
 lattice = make_hexagonal_lattice('test', 0.1, (5, 4))
 
+temperature = 0.2
+for node in lattice.iter_nodes():
+    node.data[CUBA.TEMPERATURE] = temperature
+    lattice.update_node(node)
+    temperature += 0.2
 
 # Now view the data.
 @mayavi2.standalone
@@ -18,7 +23,8 @@ def view():
     g = Glyph()
     gs = g.glyph.glyph_source
     gs.glyph_source = gs.glyph_dict['sphere_source']
-    g.glyph.glyph.scale_factor = 0.05
+    g.glyph.glyph.scale_factor = 0.02
+    g.glyph.scale_mode = 'data_scaling_off'
     mayavi.add_module(g)  # noqa
 
 if __name__ == '__main__':

--- a/examples/lattice_example.py
+++ b/examples/lattice_example.py
@@ -20,6 +20,7 @@ add_temperature(hexagonal)
 add_temperature(cubic)
 add_temperature(square)
 
+
 # Now view the data.
 @mayavi2.standalone
 def view(lattice):

--- a/examples/lattice_example.py
+++ b/examples/lattice_example.py
@@ -7,7 +7,7 @@ from simphony.core.cuba import CUBA
 
 hexagonal = make_hexagonal_lattice('test', 0.1, (5, 4))
 square = make_square_lattice('test', 0.1, (5, 4))
-cubic = make_cubic_lattice('test', 0.1, (2, 3, 4))
+cubic = make_cubic_lattice('test', 0.1, (5, 10, 12))
 
 
 def add_temperature(lattice):

--- a/examples/particles_example.py
+++ b/examples/particles_example.py
@@ -20,8 +20,6 @@ for index, point in enumerate(points):
 for indices in bonds:
     container.add_bond(Bond(particles=[uids[index] for index in indices]))
 
-# The numpy array data.
-
 
 # Now view the data.
 @mayavi2.standalone

--- a/simphony_mayavi/sources/cuds_data_accumulator.py
+++ b/simphony_mayavi/sources/cuds_data_accumulator.py
@@ -46,6 +46,14 @@ class CUDSDataAccumulator(object):
                 data = numpy.array(self._data[cuba], dtype=float)
                 index = vtk_data.add_array(data)
                 vtk_data.get_array(index).name = cuba.name
+            elif isinstance(default, numpy.ndarray) and len(default) == 3:
+                nan = numpy.array([None, None, None], dtype=float)
+                replacer = lambda x: nan if x is None else x
+                data = numpy.array(
+                    tuple(replacer(data) for data in self._data[cuba]),
+                    dtype=numpy.float)
+                index = vtk_data.add_array(data)
+                vtk_data.get_array(index).name = cuba.name
             else:
                 message = 'property {!r} is currently ignored'
                 warnings.warn(message.format(cuba))

--- a/simphony_mayavi/sources/lattice_source.py
+++ b/simphony_mayavi/sources/lattice_source.py
@@ -35,7 +35,7 @@ class LatticeSource(VTKDataSource):
             origin = origin
             data = tvtk.ImageData(spacing=spacing, origin=origin)
             data.extent = 0, size[0] - 1, 0, size[1] - 1, 0, size[2] - 1
-            # vtk ravels the point positions in a very wierd way
+            # vtk ravels the point positions in a very weird way
             # this setup has been supported by tests.
             y, z, x = numpy.meshgrid(
                 range(size[1]), range(size[2]), range(size[0]))

--- a/simphony_mayavi/sources/lattice_source.py
+++ b/simphony_mayavi/sources/lattice_source.py
@@ -35,6 +35,8 @@ class LatticeSource(VTKDataSource):
             origin = origin
             data = tvtk.ImageData(spacing=spacing, origin=origin)
             data.extent = 0, size[0] - 1, 0, size[1] - 1, 0, size[2] - 1
+            # vtk ravels the point positions in a very wierd way
+            # this setup has been supported by tests.
             y, z, x = numpy.meshgrid(
                 range(size[1]), range(size[2]), range(size[0]))
             indices = izip(x.ravel(), y.ravel(), z.ravel())

--- a/simphony_mayavi/sources/tests/test_cuds_data_accumulator.py
+++ b/simphony_mayavi/sources/tests/test_cuds_data_accumulator.py
@@ -68,7 +68,7 @@ class TestCUDSDataAccumulator(unittest.TestCase):
             accumulator[CUBA.NAME],
             [dummy_cuba_value(CUBA.NAME)] * 2)
 
-    def test_load_onto_vtk(self):
+    def test_load_scalars_onto_vtk(self):
         accumulator = CUDSDataAccumulator()
         accumulator.append(create_data_container(restrict=[CUBA.NAME]))
         accumulator.append(
@@ -81,3 +81,17 @@ class TestCUDSDataAccumulator(unittest.TestCase):
             [None, dummy_cuba_value(CUBA.TEMPERATURE)], dtype=float)
         assert_array_equal(vtk_data.get_array(0), expected)
         assert_array_equal(vtk_data.get_array(CUBA.TEMPERATURE.name), expected)
+
+    def test_load_vectors_onto_vtk(self):
+        accumulator = CUDSDataAccumulator()
+        accumulator.append(create_data_container(restrict=[CUBA.NAME]))
+        accumulator.append(
+            create_data_container(restrict=[CUBA.NAME, CUBA.VELOCITY]))
+
+        vtk_data = tvtk.PointData()
+        accumulator.load_onto_vtk(vtk_data)
+        self.assertEqual(vtk_data.number_of_arrays, 1)
+        expected = numpy.array(
+            [[None, None, None], dummy_cuba_value(CUBA.VELOCITY)], dtype=float)
+        assert_array_equal(vtk_data.get_array(0), expected)
+        assert_array_equal(vtk_data.get_array(CUBA.VELOCITY.name), expected)

--- a/simphony_mayavi/sources/tests/test_lattice_source.py
+++ b/simphony_mayavi/sources/tests/test_lattice_source.py
@@ -6,41 +6,83 @@ from numpy.testing import assert_array_equal
 from simphony.cuds.lattice import (
     Lattice, make_hexagonal_lattice, make_square_lattice,
     make_cubic_lattice, make_rectangular_lattice, make_orthorombicp_lattice)
+from simphony.core.cuba import CUBA
+
 from simphony_mayavi.sources.api import LatticeSource
 
 
 class TestLatticeSource(unittest.TestCase):
 
     def test_source_from_a_square_lattice(self):
+        shape = 2, 4
         lattice = make_square_lattice(
-            'test', 0.2, (12, 22), origin=(0.2, -2.4))
+            'test', 0.2, (2, 4), origin=(0.2, -2.4))
+        self.add_velocity(lattice)
         source = LatticeSource.from_lattice(lattice)
         data = source.data
-        self.assertEqual(data.number_of_points, 12 * 22)
+        self.assertEqual(data.number_of_points, numpy.prod(shape))
         assert_array_equal(data.origin, (0.2, -2.4, 0.0))
+
+        vectors = data.point_data.vectors.to_array()
+        for node in lattice.iter_nodes():
+            index = numpy.array(node.index + (0,))
+            point_id = data.compute_point_id(index)
+            assert_array_equal(
+                lattice.get_coordinate(node.index),
+                data.get_point(point_id)[:2])
+            assert_array_equal(vectors[point_id], index)
+
 
     def test_source_from_a_rectangular_lattice(self):
         lattice = make_rectangular_lattice(
             'test', (0.3, 0.35), (13, 23), origin=(0.2, -2.7))
+        self.add_velocity(lattice)
         source = LatticeSource.from_lattice(lattice)
         data = source.data
         self.assertEqual(data.number_of_points, 13 * 23)
         assert_array_equal(data.origin, (0.2, -2.7, 0.0))
 
+        vectors = data.point_data.vectors.to_array()
+        for node in lattice.iter_nodes():
+            index = numpy.array(node.index + (0,))
+            point_id = data.compute_point_id(index)
+            assert_array_equal(
+                lattice.get_coordinate(node.index),
+                data.get_point(point_id)[:2])
+            assert_array_equal(vectors[point_id], index)
+
     def test_source_from_a_cubic_lattice(self):
         lattice = make_cubic_lattice('test', 0.4, (14, 24, 34), (4, 5, 6))
+        self.add_velocity(lattice)
         source = LatticeSource.from_lattice(lattice)
         data = source.data
         self.assertEqual(data.number_of_points, 14 * 24 * 34)
         assert_array_equal(data.origin, (4.0, 5.0, 6.0))
 
+        vectors = data.point_data.vectors.to_array()
+        for node in lattice.iter_nodes():
+            point_id = data.compute_point_id(node.index)
+            assert_array_equal(
+                lattice.get_coordinate(node.index),
+                data.get_point(point_id))
+            assert_array_equal(vectors[point_id], node.index)
+
     def test_source_from_an_orthorombic_p_lattice(self):
         lattice = make_orthorombicp_lattice(
             'test',  (0.5, 0.54, 0.58), (15, 25, 35), (7, 9, 8))
+        self.add_velocity(lattice)
         source = LatticeSource.from_lattice(lattice)
         data = source.data
         self.assertEqual(data.number_of_points, 15 * 25 * 35)
         assert_array_equal(data.origin, (7.0, 9.0, 8.0))
+
+        vectors = data.point_data.vectors.to_array()
+        for node in lattice.iter_nodes():
+            point_id = data.compute_point_id(node.index)
+            assert_array_equal(
+                lattice.get_coordinate(node.index),
+                data.get_point(point_id))
+            assert_array_equal(vectors[point_id], node.index)
 
     def test_source_from_a_hexagonal_lattice(self):
         lattice = make_hexagonal_lattice('test', 0.1, (5, 4))
@@ -48,6 +90,7 @@ class TestLatticeSource(unittest.TestCase):
         data = source.data
         self.assertEqual(data.number_of_points, 5 * 4)
         xspace, yspace = lattice.base_vect
+
         for index, point in enumerate(data.points):
             # The lattice has 4 rows (y axis) and 5 columns (x axis).
             # Thus the correct size to unravel is (4, 5) instead of
@@ -63,3 +106,9 @@ class TestLatticeSource(unittest.TestCase):
         lattice = Lattice('test', '', (1, 1, 1), (1, 1, 1), (0, 0, 0))
         with self.assertRaises(ValueError):
             LatticeSource.from_lattice(lattice)
+
+    def add_velocity(self, lattice):
+        for node in lattice.iter_nodes():
+            index = node.index if len(node.index) == 3 else node.index + (0,)
+            node.data[CUBA.VELOCITY] = index
+            lattice.update_node(node)

--- a/simphony_mayavi/sources/tests/test_lattice_source.py
+++ b/simphony_mayavi/sources/tests/test_lattice_source.py
@@ -111,7 +111,6 @@ class TestLatticeSource(unittest.TestCase):
             point_id = data.find_point(position)
             assert_array_equal(vectors[point_id][:2], node.index)
 
-
     def test_source_from_unknown(self):
         lattice = Lattice('test', '', (1, 1, 1), (1, 1, 1), (0, 0, 0))
         with self.assertRaises(ValueError):

--- a/simphony_mayavi/sources/tests/test_lattice_source.py
+++ b/simphony_mayavi/sources/tests/test_lattice_source.py
@@ -32,7 +32,6 @@ class TestLatticeSource(unittest.TestCase):
                 data.get_point(point_id)[:2])
             assert_array_equal(vectors[point_id], index)
 
-
     def test_source_from_a_rectangular_lattice(self):
         lattice = make_rectangular_lattice(
             'test', (0.3, 0.35), (13, 23), origin=(0.2, -2.7))
@@ -86,6 +85,7 @@ class TestLatticeSource(unittest.TestCase):
 
     def test_source_from_a_hexagonal_lattice(self):
         lattice = make_hexagonal_lattice('test', 0.1, (5, 4))
+        self.add_velocity(lattice)
         source = LatticeSource.from_lattice(lattice)
         data = source.data
         self.assertEqual(data.number_of_points, 5 * 4)
@@ -101,6 +101,16 @@ class TestLatticeSource(unittest.TestCase):
                     xspace * column + 0.5 * xspace * (row % 2),
                     yspace * row,
                     0.0))
+
+        vectors = data.point_data.vectors.to_array()
+        for node in lattice.iter_nodes():
+            position = (
+                node.index[0] * xspace + 0.5 * xspace * (node.index[1] % 2),
+                node.index[1] * yspace,
+                0.0)
+            point_id = data.find_point(position)
+            assert_array_equal(vectors[point_id][:2], node.index)
+
 
     def test_source_from_unknown(self):
         lattice = Lattice('test', '', (1, 1, 1), (1, 1, 1), (0, 0, 0))


### PR DESCRIPTION
This PR adds support for coping the node data information onto the Mayavi source.

In more detail:
- The LatticeSource now will extract the scalar and vector data attached to the nodes and copy them in the mayavi source.
- The CUDSDataAccumulator have been extended to support loading vector data onto vtkFieldData objects.
- Tests have been augmented.
