### PR TITLE
Support cuba data wtih initial size

### DIFF
--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -267,6 +267,10 @@ class CubaData(MutableSequence):
                 self._virtual_size = 1
         else:
             self._virtual_size = None
+
+    def __str__(self):
+        return u"[{}]".format(",".join(str(item) for item in self))
+
     @classmethod
     def empty(cls, type_=AttributeSetType.POINTS, size=0):
         """ Return an empty sequence based wrapping a vtkAttributeDataSet.

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -172,12 +172,19 @@ class CubaData(MutableSequence):
         """ Remove the values from the attribute arrays at row=``index``.
 
         """
+        if abs(index) > len(self):
+            raise IndexError('{} is out of index range'.format(index))
         data = self._data
         n = data.number_of_arrays
-        for array_id in range(n):
-            data.get_array(array_id).remove_tuple(index)
         if n == 0 and len(self) != 0:
             self._virtual_size -= 1
+        else:
+            if len(self) != 1:
+                for array_id in range(n):
+                    data.get_array(array_id).remove_tuple(index)
+            else:
+                for array_id in reversed(range(n)):
+                    data.remove_array(array_id)
 
     def insert(self, index, value):
         """ Insert the values of the DataContainer in the arrays at row=``index``.

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -213,7 +213,7 @@ class CubaData(MutableSequence):
                 temp = numpy.insert(temp.to_array(), index, new_value, axis=0)
                 arrays.append((name, temp))
                 data.remove_array(name)  # remove array from vtk container.
-            else:
+            if n == 0:
                 # If there are no arrays yet we need to use the virtual
                 # size attribute.
                 if self._virtual_size is not None:
@@ -252,7 +252,7 @@ class CubaData(MutableSequence):
             for array_id in range(n):
                 array = data.get_array(array_id)
                 array.append(self._array_value(array.name, value))
-            else:
+            if n == 0:
                 # If there are no arrays yet we need to use the virtual
                 # size attribute.
                 if self._virtual_size is not None:

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -220,13 +220,6 @@ class CubaData(MutableSequence):
                 temp = numpy.insert(temp.to_array(), index, new_value, axis=0)
                 arrays.append((name, temp))
                 data.remove_array(name)  # remove array from vtk container.
-            if n == 0:
-                # If there are no arrays yet we need to use the virtual
-                # size attribute.
-                if self._virtual_size is not None:
-                    self._virtual_size += 1
-                else:
-                    self._virtual_size = 1
 
             # Create data and mask arrays from new CUBA keys
             for cuba in new_cubas:
@@ -252,6 +245,7 @@ class CubaData(MutableSequence):
                 mask = numpy.zeros(shape=array.shape[0], dtype=numpy.uint8)
                 new_arrays.append((cuba.name, array))
                 new_arrays.append((masked, mask))
+
             self._add_arrays(new_arrays)
 
             # Append new values.
@@ -259,16 +253,20 @@ class CubaData(MutableSequence):
             for array_id in range(n):
                 array = data.get_array(array_id)
                 array.append(self._array_value(array.name, value))
-            if n == 0:
-                # If there are no arrays yet we need to use the virtual
-                # size attribute.
-                if self._virtual_size is not None:
-                    self._virtual_size += 1
-                else:
-                    self._virtual_size = 1
         else:
             raise IndexError('{} is out of index range'.format(index))
 
+        # make sure that virtual_size is properly updated
+        n = data.number_of_arrays
+        if n == 0:
+            # If there are no arrays yet we need to use the virtual
+            # size attribute.
+            if self._virtual_size is not None:
+                self._virtual_size += 1
+            else:
+                self._virtual_size = 1
+        else:
+            self._virtual_size = None
     @classmethod
     def empty(cls, type_=AttributeSetType.POINTS, size=0):
         """ Return an empty sequence based wrapping a vtkAttributeDataSet.

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -44,9 +44,9 @@ class CubaData(MutableSequence):
 
     .. note::
 
-       - Missing values for the attribute arrays are stored in separate
-         attribute arrays named "<CUBA.name>-mask" as ``0`` while
-         present values are designated with a ``1``.
+       Missing values for the attribute arrays are stored in separate
+       attribute arrays named "<CUBA.name>-mask" as ``0`` while
+       present values are designated with a ``1``.
 
     """
 

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -213,6 +213,13 @@ class CubaData(MutableSequence):
                 temp = numpy.insert(temp.to_array(), index, new_value, axis=0)
                 arrays.append((name, temp))
                 data.remove_array(name)  # remove array from vtk container.
+            else:
+                # If there are no arrays yet we need to use the virtual
+                # size attribute.
+                if self._virtual_size is not None:
+                    self._virtual_size += 1
+                else:
+                    self._virtual_size = 1
 
             # Create data and mask arrays from new CUBA keys
             for cuba in new_cubas:
@@ -245,7 +252,13 @@ class CubaData(MutableSequence):
             for array_id in range(n):
                 array = data.get_array(array_id)
                 array.append(self._array_value(array.name, value))
-
+            else:
+                # If there are no arrays yet we need to use the virtual
+                # size attribute.
+                if self._virtual_size is not None:
+                    self._virtual_size += 1
+                else:
+                    self._virtual_size = 1
         else:
             raise IndexError('{} is out of index range'.format(index))
 

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -2,6 +2,7 @@ from collections import MutableSequence
 
 import numpy
 from tvtk.api import tvtk
+from tvtk.array_handler import _array_cache
 from enum import Enum
 from simphony.core.cuba import CUBA
 from simphony.core.data_container import DataContainer
@@ -253,6 +254,9 @@ class CubaData(MutableSequence):
             for array_id in range(n):
                 array = data.get_array(array_id)
                 array.append(self._array_value(array.name, value))
+                # invalidate the numpy cache, see issue
+                # https://github.com/enthought/mayavi/issues/197
+                _array_cache._remove_array(tvtk.to_vtk(array).__this__)
         else:
             raise IndexError('{} is out of index range'.format(index))
 

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -548,6 +548,20 @@ class TestCubaData(unittest.TestCase):
         self.assertEqual(data[3], DataContainer(VELOCITY=[0, 0, 0.34]))
         self._assert_len(data, 4)
 
+    def test_append_on_empty(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data)
+
+        # when
+        data.append(DataContainer(VELOCITY=[0, 0, 0.34]))
+        data.append(DataContainer(VELOCITY=[0, 0, 0.24]))
+
+        # then
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.24]))
+        self.assertEqual(data[0], DataContainer(VELOCITY=[0, 0, 0.34]))
+
     def test_append_with_initial_size(self):
         # given
         point_data = tvtk.PointData()
@@ -648,6 +662,20 @@ class TestCubaData(unittest.TestCase):
                     RADIUS=values['RADIUS'][old_index],
                     TEMPERATURE=values['TEMPERATURE'][old_index],
                     VELOCITY=values['VELOCITY'][old_index]))
+        self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
+
+    def test_insert_on_empty(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data)
+
+        # when
+        data.insert(0, DataContainer(VELOCITY=[0, 0, 0.34]))
+        data.insert(0, DataContainer(VELOCITY=[0, 0, 0.24]))
+
+        # then
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0], DataContainer(VELOCITY=[0, 0, 0.24]))
         self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
 
     def test_insert_with_initial_size(self):
@@ -774,7 +802,31 @@ class TestCubaData(unittest.TestCase):
         # when
         for index in range(5):
             data.append(DataContainer(MASS=index))
-        print data
+        for index in reversed(range(5)):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+    def test_insert_delete_cycle(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=3)
+
+        # when
+        for index in range(5):
+            data.insert(0, DataContainer(MASS=index))
+        for index in reversed(range(8)):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+        # when
+        for index in range(5):
+            data.insert(0, DataContainer(MASS=index))
         for index in reversed(range(5)):
             del data[index]
 

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -308,6 +308,24 @@ class TestCubaData(unittest.TestCase):
         with self.assertRaises(IndexError):
             data[7] = DataContainer(RADIUS=0.2, TEMPERATURE=-4.5)
 
+    def test_setitem_empty_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=3)
+
+        # when
+        for index in range(3):
+            data[index] = DataContainer()
+
+        # then
+        for index in range(3):
+            self.assertEqual(data[index], DataContainer())
+        self._assert_len(data, 0)
+
+        # when/then
+        with self.assertRaises(IndexError):
+            data[4] = DataContainer()
+
     def test_setitem_with_unsupported_cuba(self):
         # given
         data = self.data
@@ -512,6 +530,33 @@ class TestCubaData(unittest.TestCase):
         self.assertEqual(data[5], DataContainer(VELOCITY=[0, 0, 0.34]))
         self._assert_len(data, 6)
 
+    def test_append_empty_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        data.append(DataContainer())
+
+        # then
+        self.assertEqual(len(data), 6)
+        for index in range(5):
+            self.assertEqual(data[index], DataContainer())
+        self.assertEqual(data[5], DataContainer())
+        self._assert_len(data, 6)
+
+    def test_append_empty_on_empty_container(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=None)
+
+        # when
+        data.append(DataContainer())
+
+        # then
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0], DataContainer())
+
     def test_append_with_new_cuba(self):
         # given
         data = self.data
@@ -587,6 +632,31 @@ class TestCubaData(unittest.TestCase):
             self.assertEqual(data[index], DataContainer())
         self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
 
+    def test_insert_empty_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        data.insert(1, DataContainer())
+
+        # then
+        self.assertEqual(len(data), 6)
+        for index in range(6):
+            self.assertEqual(data[index], DataContainer())
+
+    def test_insert_empty_on_empty_container(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=None)
+
+        # when
+        data.insert(1, DataContainer())
+
+        # then
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0], DataContainer())
+
     def test_insert_with_new_cuba(self):
         # given
         data = self.data
@@ -594,9 +664,9 @@ class TestCubaData(unittest.TestCase):
 
         # when
         data.insert(1, DataContainer(VELOCITY=[0, 0, 0.34], MASS=0.3))
-        self._assert_len(data, 4)
 
         # then
+        self._assert_len(data, 4)
         self.assertEqual(len(data), 4)
         for old_index, index in enumerate((0, 2, 3)):
             result = data[index]

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -481,6 +481,39 @@ class TestCubaData(unittest.TestCase):
                     VELOCITY=values['VELOCITY'][old_index]))
         self._assert_len(data, 2)
 
+    def test_delitem_invalid(self):
+        # given
+        data = self.data
+
+        # then/when
+        with self.assertRaises(IndexError):
+            del data[145]
+
+    def test_delitem_to_empty_container(self):
+        # given
+        data = self.data
+
+        # when
+        for index in reversed(range(len(data))):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+    def test_delitem_with_initial_size_to_empty_container(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        for index in reversed(range(len(data))):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
     def test_delitem_with_initial_size(self):
         # given
         point_data = tvtk.PointData()

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -44,6 +44,14 @@ class TestCubaData(unittest.TestCase):
         # then
         self.assertEqual(len(data), 4)
 
+    def test_len_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=19)
+
+        # then
+        self.assertEqual(len(data), 19)
+
     def test_initialize_empty_points(self):
         # given
         data = CubaData.empty()
@@ -62,6 +70,15 @@ class TestCubaData(unittest.TestCase):
         self.assertEqual(data.cubas, set([]))
         self.assertIsInstance(data._data, tvtk.CellData)
 
+    def test_initialize_empty_and_size(self):
+        # given
+        data = CubaData.empty(size=12)
+
+        # then
+        self.assertEqual(len(data), 12)
+        self.assertEqual(data.cubas, set([]))
+        self.assertIsInstance(data._data, tvtk.PointData)
+
     def test_initialize_with_some_masked_point_data(self):
         # given
         point_data = tvtk.PointData()
@@ -76,6 +93,7 @@ class TestCubaData(unittest.TestCase):
         data = CubaData(attribute_data=point_data)
 
         # then
+        self.assertEqual(len(data), 3)
         self.assertEqual(data.cubas, {CUBA.TEMPERATURE, CUBA.RADIUS})
         self.assertSequenceEqual(
             point_data.get_array(CUBA.TEMPERATURE.name), [1, 2, 3])
@@ -99,6 +117,7 @@ class TestCubaData(unittest.TestCase):
         data = CubaData(attribute_data=point_data)
 
         # then
+        self.assertEqual(len(data), 3)
         self.assertEqual(data.cubas, {CUBA.TEMPERATURE, CUBA.RADIUS})
         self.assertSequenceEqual(
             point_data.get_array(CUBA.TEMPERATURE.name), [1, 2, 3])
@@ -121,6 +140,20 @@ class TestCubaData(unittest.TestCase):
         # when/then
         with self.assertRaises(ValueError):
             CubaData(attribute_data=point_data)
+
+    def test_initialize_with_point_data_and_size(self):
+        # given
+        point_data = tvtk.PointData()
+        index = point_data.add_array([1, 2, 3])
+        point_data.get_array(index).name = 'MASS'
+
+        # when/then
+        with self.assertRaises(ValueError):
+            CubaData(attribute_data=point_data, size=3)
+
+        # when/then
+        with self.assertRaises(ValueError):
+            CubaData(attribute_data=point_data, size=11)
 
     def test_initialize_with_variable_lenth_point_data(self):
         # given
@@ -147,6 +180,32 @@ class TestCubaData(unittest.TestCase):
                 TEMPERATURE=values['TEMPERATURE'][index],
                 VELOCITY=values['VELOCITY'][index])
             self.assertEqual(result, expected)
+
+        # when/then
+        with self.assertRaises(IndexError):
+            data[4]
+
+    def test_getitem_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when/then
+        for index in range(5):
+            self.assertEqual(data[index], DataContainer())
+
+        # when/then
+        with self.assertRaises(IndexError):
+            data[6]
+
+        # when/then
+        with self.assertRaises(IndexError):
+            data[-6]
+
+    def test_getitem_on_empty_container(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data)
 
         # when/then
         with self.assertRaises(IndexError):
@@ -221,6 +280,33 @@ class TestCubaData(unittest.TestCase):
         # when/then
         with self.assertRaises(IndexError):
             data[4] = DataContainer(RADIUS=0.2, TEMPERATURE=-4.5)
+
+    def test_setitem_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        for index in range(3):
+            data[index] = DataContainer(
+                RADIUS=[34, 32, 31][index],
+                TEMPERATURE=[-1, -2, -3][index],
+                VELOCITY=[0.2, -0.1, -0.54])
+
+        # then
+        self._assert_len(data, 5)
+        for index in range(3):
+            self.assertEqual(
+                data[index], DataContainer(
+                    RADIUS=[34, 32, 31][index],
+                    TEMPERATURE=[-1, -2, -3][index],
+                    VELOCITY=[0.2, -0.1, -0.54]))
+        for index in range(3, 5):
+            self.assertEqual(data[index], DataContainer())
+
+        # when/then
+        with self.assertRaises(IndexError):
+            data[7] = DataContainer(RADIUS=0.2, TEMPERATURE=-4.5)
 
     def test_setitem_with_unsupported_cuba(self):
         # given
@@ -377,6 +463,20 @@ class TestCubaData(unittest.TestCase):
                     VELOCITY=values['VELOCITY'][old_index]))
         self._assert_len(data, 2)
 
+    def test_delitem_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        del data[1]
+
+        # the
+        self.assertEqual(len(data), 4)
+        for index in range(4):
+            self.assertEqual(data[index], DataContainer())
+        self._assert_len(data, 4)
+
     def test_append(self):
         # given
         data = self.data
@@ -396,6 +496,21 @@ class TestCubaData(unittest.TestCase):
                     VELOCITY=values['VELOCITY'][index]))
         self.assertEqual(data[3], DataContainer(VELOCITY=[0, 0, 0.34]))
         self._assert_len(data, 4)
+
+    def test_append_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        data.append(DataContainer(VELOCITY=[0, 0, 0.34]))
+
+        # then
+        self.assertEqual(len(data), 6)
+        for index in range(5):
+            self.assertEqual(data[index], DataContainer())
+        self.assertEqual(data[5], DataContainer(VELOCITY=[0, 0, 0.34]))
+        self._assert_len(data, 6)
 
     def test_append_with_new_cuba(self):
         # given
@@ -455,6 +570,21 @@ class TestCubaData(unittest.TestCase):
                     RADIUS=values['RADIUS'][old_index],
                     TEMPERATURE=values['TEMPERATURE'][old_index],
                     VELOCITY=values['VELOCITY'][old_index]))
+        self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
+
+    def test_insert_with_initial_size(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=5)
+
+        # when
+        data.insert(1, DataContainer(VELOCITY=[0, 0, 0.34]))
+
+        # then
+        self._assert_len(data, 6)
+        self.assertEqual(len(data), 6)
+        for old_index, index in enumerate((0, 2, 3, 4, 5)):
+            self.assertEqual(data[index], DataContainer())
         self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
 
     def test_insert_with_new_cuba(self):

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -731,6 +731,57 @@ class TestCubaData(unittest.TestCase):
                     VELOCITY=values['VELOCITY'][old_index]))
         self.assertEqual(data[1], DataContainer(VELOCITY=[0, 0, 0.34]))
 
+    def test_append_pop_cycle(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=3)
+
+        # when
+        for index in range(5):
+            data.append(DataContainer(MASS=index))
+        for _ in range(8):
+            data.pop(0)
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+        # when
+        for index in range(5):
+            data.append(DataContainer(MASS=index))
+        for _ in range(5):
+            data.pop(0)
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+    def test_append_delete_cycle(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data, size=3)
+
+        # when
+        for index in range(5):
+            data.append(DataContainer(MASS=index))
+        for index in reversed(range(8)):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
+        # when
+        for index in range(5):
+            data.append(DataContainer(MASS=index))
+        print data
+        for index in reversed(range(5)):
+            del data[index]
+
+        # then
+        self.assertEqual(len(data), 0)
+        self.assertEqual(data.cubas, set([]))
+
     def _assert_len(self, data, length):
         n = data._data.number_of_arrays
         for array_id in range(n):

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -3,15 +3,15 @@ import uuid
 from functools import partial
 
 from tvtk.api import tvtk
-
 from simphony.cuds.particles import Particle
 from simphony.core.data_container import DataContainer
 from simphony.core.cuba import CUBA
 from simphony.testing.utils import (
-    compare_data_containers, compare_particles, create_particles)
+    compare_data_containers, compare_particles)
 from simphony.testing.abc_check_particles import (
     ContainerManipulatingBondsCheck, ContainerAddParticlesCheck,
     ContainerAddBondsCheck, ContainerManipulatingParticlesCheck)
+
 from simphony_mayavi.cuds.api import VTKParticles
 from simphony_mayavi.core.api import supported_cuba
 
@@ -78,7 +78,7 @@ class TestParticlesDataContainer(unittest.TestCase):
         self.assertEqual(data, ret_data)
         self.assertIsNot(data, ret_data)
 
-    def test_initialization_with_empty_dataset(self):
+    def test_initialization_with_expected_size(self):
         data_set = tvtk.PolyData(points=tvtk.Points(), lines=[])
         container = VTKParticles(name='test', data_set=data_set)
         particle = Particle(coordinates=(0.0, 1.0, 2.0), data=DataContainer())

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -54,12 +54,26 @@ class VTKParticles(ABCParticles):
 
         #: The currently supported and stored CUBA keywords.
         self.supported_cuba = supported_cuba()
+
         #: Easy access to the vtk PointData structure
+        data = data_set.point_data
+        if data.number_of_arrays == 0 and not self.initialized:
+            size = data_set.number_of_points
+        else:
+            size = None
         self.point_data = CubaData(
-            data_set.point_data, stored_cuba=self.supported_cuba)
+            data, stored_cuba=self.supported_cuba, size=size)
+
         #: Easy access to the vtk CellData structure
+        data = data_set.cell_data
+        ncells = data_set.number_of_cells
+        if data.number_of_arrays == 0 and ncells != 0:
+            size = ncells
+        else:
+            size = None
         self.bond_data = CubaData(
-            data_set.cell_data, stored_cuba=self.supported_cuba)
+            data, stored_cuba=self.supported_cuba, size=size)
+
         #: Easy access to the lines vtk CellArray structure
         self.bonds = CellCollection(data_set.lines)
 


### PR DESCRIPTION
This PR implements #61 

In more details the following operations are now possible on an empty or pre-initialized sequence:
- append with DataContainer instance (either empty or not)
- insert with DataContainer instance (either empty or not)
- delete a DataContainer instance
