### PR TITLE
Make sure that cuba_data getitem returns values with the correct dtype

### DIFF
--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -274,7 +274,7 @@ class CubaData(MutableSequence):
             self._virtual_size = None
 
     def __str__(self):
-        return u"[{0}]".format(",".join(str(item) for item in self))
+        return u"[{}]".format(",".join(str(item) for item in self))
 
     @classmethod
     def empty(cls, type_=AttributeSetType.POINTS, size=0):

--- a/simphony_mayavi/core/cuba_data.py
+++ b/simphony_mayavi/core/cuba_data.py
@@ -5,6 +5,7 @@ from tvtk.api import tvtk
 from tvtk.array_handler import _array_cache
 from enum import Enum
 from simphony.core.cuba import CUBA
+from simphony.core.keywords import KEYWORDS
 from simphony.core.data_container import DataContainer
 
 from simphony_mayavi.core.cuba_utils import (
@@ -165,7 +166,7 @@ class CubaData(MutableSequence):
             data.get_array(names[name])
             for name in names if '-mask' in name]
         values = {
-            CUBA[array.name]: array[index]
+            CUBA[array.name]: KEYWORDS[array.name].dtype(array[index])
             for mask, array in zip(masks, arrays) if mask[index]}
         return DataContainer(values)
 
@@ -273,7 +274,7 @@ class CubaData(MutableSequence):
             self._virtual_size = None
 
     def __str__(self):
-        return u"[{}]".format(",".join(str(item) for item in self))
+        return u"[{0}]".format(",".join(str(item) for item in self))
 
     @classmethod
     def empty(cls, type_=AttributeSetType.POINTS, size=0):

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -610,7 +610,7 @@ class TestCubaData(unittest.TestCase):
         values = self.values
 
         # when
-        data.append(DataContainer(VELOCITY=[0, 0, 0.34]))
+        data.append(DataContainer(MASS=34, VELOCITY=[0, 0, 0.34]))
 
         # then
         self.assertEqual(len(data), 4)
@@ -622,7 +622,7 @@ class TestCubaData(unittest.TestCase):
                     TEMPERATURE=values['TEMPERATURE'][index],
                     VELOCITY=values['VELOCITY'][index]))
         self.assertEqual(
-            data[3], DataContainer(VELOCITY=[0, 0, 0.34]))
+            data[3], DataContainer(MASS=34.0, VELOCITY=[0, 0, 0.34]))
 
     def test_append_with_unsupported_cuba(self):
         # given

--- a/simphony_mayavi/core/tests/test_cuba_data.py
+++ b/simphony_mayavi/core/tests/test_cuba_data.py
@@ -610,7 +610,7 @@ class TestCubaData(unittest.TestCase):
         values = self.values
 
         # when
-        data.append(DataContainer(MASS=34, VELOCITY=[0, 0, 0.34]))
+        data.append(DataContainer(VELOCITY=[0, 0, 0.34]))
 
         # then
         self.assertEqual(len(data), 4)
@@ -622,7 +622,7 @@ class TestCubaData(unittest.TestCase):
                     TEMPERATURE=values['TEMPERATURE'][index],
                     VELOCITY=values['VELOCITY'][index]))
         self.assertEqual(
-            data[3], DataContainer(MASS=34.0, VELOCITY=[0, 0, 0.34]))
+            data[3], DataContainer(VELOCITY=[0, 0, 0.34]))
 
     def test_append_with_unsupported_cuba(self):
         # given
@@ -833,6 +833,21 @@ class TestCubaData(unittest.TestCase):
         # then
         self.assertEqual(len(data), 0)
         self.assertEqual(data.cubas, set([]))
+
+    def test_swap_with_integer_cuba(self):
+        # given
+        point_data = tvtk.PointData()
+        data = CubaData(attribute_data=point_data)
+        for index in range(5):
+            data.append(DataContainer(STATUS=index))
+
+        # when
+        data[0] = data[4]
+
+        # then
+        self.assertEqual(data[0], DataContainer(STATUS=4))
+        for index in range(1, 5):
+            self.assertEqual(data[index], DataContainer(STATUS=index))
 
     def _assert_len(self, data, length):
         n = data._data.number_of_arrays


### PR DESCRIPTION
This PR provides a workaround for https://github.com/enthought/mayavi/issues/206 and makes sure that the retrieved values have the expected datatype
