### PR TITLE
Rework mask array storing

### DIFF
--- a/simphony_mayavi/sources/tests/test_mesh_source.py
+++ b/simphony_mayavi/sources/tests/test_mesh_source.py
@@ -15,7 +15,7 @@ from simphony_mayavi.core.api import (
 from simphony_mayavi.sources.api import MeshSource
 
 
-class TestParticlesSource(unittest.TestCase):
+class TestMeshSource(unittest.TestCase):
 
     def setUp(self):
         self.points = points = numpy.array([
@@ -45,7 +45,7 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(points), number_of_points)
         self.assertEqual(len(source.point2index), number_of_points)
 
-        self.assertEqual(source.data.point_data.number_of_arrays, 2)
+        self.assertEqual(source.data.point_data.number_of_arrays, 1)
         temperature = source.data.point_data.get_array('TEMPERATURE')
         for key, index in source.point2index.iteritems():
             point = container.get_point(key)
@@ -70,7 +70,7 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(cells), number_of_cells)
         self.assertEqual(len(source.element2index), number_of_cells)
 
-        self.assertEqual(source.data.cell_data.number_of_arrays, 2)
+        self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in source.element2index.iteritems():
             cell = container.get_cell(key)
@@ -99,7 +99,7 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(edges), number_of_edges)
         self.assertEqual(len(source.element2index), number_of_edges)
 
-        self.assertEqual(source.data.cell_data.number_of_arrays, 2)
+        self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in source.element2index.iteritems():
             edge = container.get_edge(key)
@@ -128,7 +128,7 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(faces), number_of_faces)
         self.assertEqual(len(source.element2index), number_of_faces)
 
-        self.assertEqual(source.data.cell_data.number_of_arrays, 2)
+        self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in source.element2index.iteritems():
             face = container.get_face(key)
@@ -169,7 +169,8 @@ class TestParticlesSource(unittest.TestCase):
             len(self.faces) + len(self.edges) + len(self.cells)
         self.assertEqual(len(elements), number_of_elements)
         self.assertEqual(len(source.element2index), number_of_elements)
-        self.assertEqual(source.data.cell_data.number_of_arrays, 2)
+        self.assertEqual(source.data.point_data.number_of_arrays, 1)
+        self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in source.element2index.iteritems():
             cell_type = vtk_source.get_cell_type(index)

--- a/simphony_mayavi/sources/tests/test_particles_sources.py
+++ b/simphony_mayavi/sources/tests/test_particles_sources.py
@@ -62,15 +62,12 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(points), number_of_particles)
         self.assertEqual(len(source.point2index), number_of_particles)
 
-        # two arrays TEMPERATURE and TEMPERATURE-mask
-        self.assertEqual(source.data.point_data.number_of_arrays, 2)
+        self.assertEqual(source.data.point_data.number_of_arrays, 1)
         temperature = source.data.point_data.get_array('TEMPERATURE')
         for key, index in source.point2index.iteritems():
             point = container.get_particle(key)
             assert_array_equal(points[index], point.coordinates)
             self.assertEqual(temperature[index], point.data[CUBA.TEMPERATURE])
-        temperature_mask = source.data.point_data.get_array('TEMPERATURE-mask')
-        assert_array_equal(temperature_mask, numpy.ones_like(temperature))
 
     def test_bonds(self):
         container = self.container
@@ -82,13 +79,10 @@ class TestParticlesSource(unittest.TestCase):
         self.assertEqual(len(bonds), number_of_bonds)
         self.assertEqual(len(source.bond2index), number_of_bonds)
 
-        # two arrays TEMPERATURE and TEMPERATURE-mask
-        self.assertEqual(source.data.cell_data.number_of_arrays, 2)
+        self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in source.bond2index.iteritems():
             bond = container.get_bond(key)
             particles = [source.point2index[uid] for uid in bond.particles]
             self.assertEqual(bonds[index], particles)
             self.assertEqual(temperature[index], bond.data[CUBA.TEMPERATURE])
-        temperature_mask = source.data.cell_data.get_array('TEMPERATURE-mask')
-        assert_array_equal(temperature_mask, numpy.ones_like(temperature))


### PR DESCRIPTION
Masked arrays as stored on a separate `masks` attribute of a `CUBAData` container.

fixes #74 
