### PR TITLE
load files into CUDS containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ addons:
     - python-imaging
     - python-pip
 before_install:
-  - sh -e /etc/init.d/xvfb start
   - git clone --depth=1 --branch=master git://vtk.org/VTKData.git ../VTKData
+  - sh -e /etc/init.d/xvfb start
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ python:
 virtualenv:
   system_site_packages: true
 env:
-  global:
-    - ETS_TOOKIT=qt4
-    - DISPLAY=:99.0
-    - VTKDATA=~/VTKData
-  matrix:
-    - SIMPHONY_VERSION=0.1.5
-    - SIMPHONY_VERSION=master
-    allow_failures:
+  - SIMPHONY_VERSION=0.1.5
+  - SIMPHONY_VERSION=master
+matrix:
+  allow_failures:
     - env: SIMPHONY_VERSION=master
 addons:
   apt:
@@ -23,6 +19,9 @@ addons:
     - python-imaging
     - python-pip
 before_install:
+  - export ETS_TOOKIT=qt4
+  - export DISPLAY=:99.0
+  - export VTKDATA=~/VTKData
   - git clone --depth=1 --branch=master git://vtk.org/VTKData.git ../VTKData
   - sh -e /etc/init.d/xvfb start
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - export ETS_TOOLKIT=qt4
   - git clone --depth=1 --branch=master git://vtk.org/VTKData.git VTKData
   - export VTKDATA=~/VTKData
+  - ls ${VTKDATA}/Data
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - export ETS_TOOLKIT=qt4
+  - git clone --depth=1 --branch=master git://vtk.org/VTKData.git VTKData
+  - export VTKDATA=~/VTKDATA
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ addons:
 before_install:
   - export ETS_TOOKIT=qt4
   - export DISPLAY=:99.0
-  - export VTKDATA=~/VTKData
-  - git clone --depth=1 --branch=master git://vtk.org/VTKData.git ../VTKData
+  - export VTKDATA=/home/travis/VTKData
+  - git clone --depth=1 --branch=master git://vtk.org/VTKData.git /home/travis/VTKData
   - sh -e /etc/init.d/xvfb start
 install:
   # see issue https://github.com/enthought/traitsui/issues/206

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - export ETS_TOOLKIT=qt4
   - git clone --depth=1 --branch=master git://vtk.org/VTKData.git VTKData
-  - export VTKDATA=~/VTKDATA
+  - export VTKDATA=~/VTKData
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,14 @@ python:
 virtualenv:
   system_site_packages: true
 env:
-  - SIMPHONY_VERSION=0.1.5
-  - SIMPHONY_VERSION=master
-matrix:
-  allow_failures:
+  global:
+    - ETS_TOOKIT=qt4
+    - DISPLAY=:99.0
+    - VTKDATA=~/VTKData
+  matrix:
+    - SIMPHONY_VERSION=0.1.5
+    - SIMPHONY_VERSION=master
+    allow_failures:
     - env: SIMPHONY_VERSION=master
 addons:
   apt:
@@ -19,12 +23,8 @@ addons:
     - python-imaging
     - python-pip
 before_install:
-  - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - export ETS_TOOLKIT=qt4
-  - git clone --depth=1 --branch=master git://vtk.org/VTKData.git VTKData
-  - export VTKDATA=~/VTKData
-  - ls ${VTKDATA}
+  - git clone --depth=1 --branch=master git://vtk.org/VTKData.git ../VTKData
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export ETS_TOOLKIT=qt4
   - git clone --depth=1 --branch=master git://vtk.org/VTKData.git VTKData
   - export VTKDATA=~/VTKData
-  - ls ${VTKDATA}/Data
+  - ls ${VTKDATA}
 install:
   # see issue https://github.com/enthought/traitsui/issues/206
   - pip install traitsui!=4.5.0

--- a/simphony_mayavi/api.py
+++ b/simphony_mayavi/api.py
@@ -1,5 +1,6 @@
 from .show import show
 from .snapshot import snapshot
 from .adapt2cuds import adapt2cuds
+from .load import load
 
-__all__ = ['show', 'snapshot', 'adapt2cuds']
+__all__ = ['show', 'snapshot', 'adapt2cuds', 'load']

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -5,6 +5,30 @@ from simphony_mayavi.adapt2cuds import adapt2cuds
 
 def load(filename, name=None, kind=None, rename_arrays=None):
     """ Load the file data into a CUDS container.
+
+    Parameters
+    ----------
+    filename : string
+        The file name of the file to load.
+
+    name : string
+        The name of the returned CUDS container. Default is 'CUDS container'.
+
+    kind : {'mesh', 'lattice', 'particles'}
+        The kind of the container to return. Default is None, where
+        the function will use some heuristics to infer the most
+        appropriate type of CUDS container to return
+
+    rename_array : dict
+        Dictionary mapping the array names used in the dataset object
+        to their related CUBA keywords that will be used in the returned
+        CUDS container.
+
+        .. note::
+
+           Only CUBA keywords are supported for array names so use this
+           option to provide a translation mapping to the CUBA keys.
+
     """
     data_set = _read(filename)
     return adapt2cuds(
@@ -12,7 +36,7 @@ def load(filename, name=None, kind=None, rename_arrays=None):
 
 
 def _read(filename):
-    """ Find a suitable reader and read in the tvtk.Dataset.
+    """ Find a suitable reader and read the tvtk.Dataset.
     """
     metasource = registry.get_file_reader(filename)
     if metasource is None:

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -1,0 +1,32 @@
+from mayavi.core.api import registry
+
+from simphony_mayavi.adapt2cuds import adapt2cuds
+
+
+def load(filename, name=None, kind=None, rename_arrays=None):
+    data_set = _read(filename)
+    return adapt2cuds(
+        data_set, name, kind, rename_arrays)
+
+
+def _read(filename):
+    """ Find a suitable reader and read in the tvtk.Dataset.
+    """
+    metasource = registry.get_file_reader(filename)
+    if metasource is None:
+        message = 'No suitable reader found for file: {}'
+        raise RuntimeError(message.format(filename))
+    if metasource.factory is None:
+        source = metasource.get_callable()()
+        source.initialize(filename)
+        source.update()
+        reader = source.reader
+    else:
+        message = 'Mayavi reader that requires a scene is not supported : {}'
+        raise NotImplementedError(message.format(filename))
+
+    if len(source.outputs) != 1:
+        message = 'Only one output is expected from the reader'
+        raise RuntimeError(message)
+
+    return reader.output

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -10,6 +10,7 @@ def load(filename, name=None, kind=None, rename_arrays=None):
     return adapt2cuds(
         data_set, name, kind, rename_arrays)
 
+
 def _read(filename):
     """ Find a suitable reader and read in the tvtk.Dataset.
     """

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -5,11 +5,10 @@ from simphony_mayavi.adapt2cuds import adapt2cuds
 
 def load(filename, name=None, kind=None, rename_arrays=None):
     """ Load the file data into a CUDS container.
-    """ 
+    """
     data_set = _read(filename)
     return adapt2cuds(
         data_set, name, kind, rename_arrays)
-
 
 def _read(filename):
     """ Find a suitable reader and read in the tvtk.Dataset.

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -17,7 +17,7 @@ def load(filename, name=None, kind=None, rename_arrays=None):
     kind : {'mesh', 'lattice', 'particles'}
         The kind of the container to return. Default is None, where
         the function will use some heuristics to infer the most
-        appropriate type of CUDS container to return
+        appropriate type of CUDS container to return (using adapt2cuds).
 
     rename_array : dict
         Dictionary mapping the array names used in the dataset object

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -4,6 +4,8 @@ from simphony_mayavi.adapt2cuds import adapt2cuds
 
 
 def load(filename, name=None, kind=None, rename_arrays=None):
+    """ Load the file data into a CUDS container.
+    """ 
     data_set = _read(filename)
     return adapt2cuds(
         data_set, name, kind, rename_arrays)

--- a/simphony_mayavi/load.py
+++ b/simphony_mayavi/load.py
@@ -30,5 +30,4 @@ def _read(filename):
     if len(source.outputs) != 1:
         message = 'Only one output is expected from the reader'
         raise RuntimeError(message)
-
     return reader.output

--- a/simphony_mayavi/plugin.py
+++ b/simphony_mayavi/plugin.py
@@ -1,8 +1,8 @@
 from simphony_mayavi._version import full_version as __version__
-from simphony_mayavi.api import show, snapshot, adapt2cuds
+from simphony_mayavi.api import show, snapshot, adapt2cuds, load
 from simphony_mayavi.cuds.api import VTKParticles, VTKLattice, VTKMesh
 
 __all__ = [
-    'show', 'snapshot', 'adapt2cuds',
+    'show', 'snapshot', 'adapt2cuds', 'load',
     '__version__',
     'VTKParticles', 'VTKLattice', 'VTKMesh']

--- a/simphony_mayavi/tests/test_load.py
+++ b/simphony_mayavi/tests/test_load.py
@@ -2,8 +2,9 @@ import os
 import unittest
 
 
+from simphony.core.cuba import CUBA
 from simphony_mayavi.load import load
-from simphony_mayavi.cuds.api import VTKParticles, VTKMesh
+from simphony_mayavi.cuds.api import VTKParticles, VTKMesh, VTKLattice
 
 
 VTKDATA = os.environ.get('VTKDATA', None)
@@ -31,6 +32,13 @@ class TestLoad(unittest.TestCase):
         container = load(filename)
         self.assertIsInstance(container, VTKParticles)
         self.assertEqual(sum(1 for item in container.iter_particles()), 12)
+
+    def test_load_vase_1comp_vti(self):
+        # The vase_1comp_vti files contains only points.
+        filename = os.path.join(self.data_folder, 'vase_1comp.vti')
+        container = load(
+            filename, rename_arrays={'SLCImage': CUBA.TEMPERATURE})
+        self.assertIsInstance(container, VTKLattice)
 
     def test_load_vwgt_graph(self):
         # The vwgt.graph file do not have a predefined reader.

--- a/simphony_mayavi/tests/test_load.py
+++ b/simphony_mayavi/tests/test_load.py
@@ -31,3 +31,12 @@ class TestLoad(unittest.TestCase):
         container = load(filename)
         self.assertIsInstance(container, VTKParticles)
         self.assertEqual(sum(1 for item in container.iter_particles()), 12)
+
+    def test_load_vwgt_graph(self):
+        # The vwgt.graph file do not have a predefined reader.
+        filename = os.path.join(self.data_folder, 'vwgt.graph')
+
+        with self.assertRaises(RuntimeError) as context:
+            load(filename)
+        message = context.exception.message
+        self.assertIn('No suitable reader found', message)

--- a/simphony_mayavi/tests/test_load.py
+++ b/simphony_mayavi/tests/test_load.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+
+
+from simphony_mayavi.load import load
+from simphony_mayavi.cuds.api import VTKParticles, VTKMesh
+
+
+VTKDATA = os.environ.get('VTKDATA', None)
+
+
+class TestLoad(unittest.TestCase):
+
+    @unittest.skipIf(VTKDATA is None, 'VTKDATA folder not available')
+    def setUp(self):
+        self.data_folder = os.path.join(VTKDATA, 'Data')
+
+    def test_load_blowGeom_vtk(self):
+        # The blowGeom.vtk files contains a mesh surface.
+        filename = os.path.join(self.data_folder, 'blowGeom.vtk')
+        container = load(filename)
+        self.assertIsInstance(container, VTKMesh)
+        self.assertEqual(sum(1 for item in container.iter_points()), 687)
+        self.assertEqual(sum(1 for item in container.iter_faces()), 1057)
+        self.assertEqual(sum(1 for item in container.iter_edges()), 0)
+        self.assertEqual(sum(1 for item in container.iter_cells()), 0)
+
+    def test_load_vtk_vtk(self):
+        # The vtk.vtk files contains only points and lines
+        filename = os.path.join(self.data_folder, 'vtk.vtk')
+        container = load(filename)
+        self.assertIsInstance(container, VTKParticles)
+        self.assertEqual(sum(1 for item in container.iter_particles()), 12)

--- a/simphony_mayavi/tests/test_load.py
+++ b/simphony_mayavi/tests/test_load.py
@@ -7,7 +7,7 @@ from simphony_mayavi.load import load
 from simphony_mayavi.cuds.api import VTKParticles, VTKMesh, VTKLattice
 
 
-VTKDATA = os.environ.get('VTKDATA', None)
+VTKDATA = os.environ.get('VTKDATA')
 
 
 class TestLoad(unittest.TestCase):

--- a/simphony_mayavi/tests/test_plugin_loading.py
+++ b/simphony_mayavi/tests/test_plugin_loading.py
@@ -5,7 +5,9 @@ PLUGINAPI = [
     'snapshot',
     'VTKParticles',
     'VTKLattice',
-    'VTKMesh']
+    'VTKMesh',
+    'adapt2cuds',
+    'load']
 
 
 class TestPluginLoading(unittest.TestCase):


### PR DESCRIPTION
A new `load` function is added to the simphony-mayavi plugin to allow reading mayavi loadable files into SimPhoNy as CUDS containers (i.e Particles, Mesh, and Lattice) using the vtk cuds wrappers.

in more details
- A new `load` method is provided that checks the mayavi reader registry for compatible files and tries to adapt the loaded dataset to the appropriate CUDS container type.
- Tests use the VTKData repo for example vtk files.

Provides #43
