### PR TITLE
Upgrade particle support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 - mayavi[app] >= 4.4.0
-- simphony[H5IO] == 0.1.5
+- simphony[H5IO] == 0.2.1
 
 Optional requirements
 ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/particles_example.py
+++ b/examples/particles_example.py
@@ -8,17 +8,17 @@ bonds = array([[0, 1], [0, 3], [1, 3, 2]])
 temperature = array([10., 20., 30., 40.])
 
 particles = Particles('test')
-uids = []
-for index, point in enumerate(points):
-    uid = particles.add_particle(
-        Particle(
-            coordinates=point,
-            data=DataContainer(TEMPERATURE=temperature[index])))
-    uids.append(uid)
 
-for indices in bonds:
-    particles.add_bond(Bond(particles=[uids[index] for index in indices]))
+# add particles
+particle_iter = (Particle(coordinates=point,
+                          data=DataContainer(TEMPERATURE=temperature[index]))
+                 for index, point in enumerate(points))
+uids = particles.add_particles(particle_iter)
 
+# add bonds
+bond_iter = (Bond(particles=[uids[index] for index in indices])
+             for indices in bonds)
+particles.add_bonds(bond_iter)
 
 if __name__ == '__main__':
     from simphony.visualisation import mayavi_tools

--- a/examples/particles_mayavi2.py
+++ b/examples/particles_mayavi2.py
@@ -9,16 +9,17 @@ bonds = array([[0, 1], [0, 3], [1, 3, 2]])
 temperature = array([10., 20., 30., 40.])
 
 container = Particles('test')
-uids = []
-for index, point in enumerate(points):
-    uid = container.add_particle(
-        Particle(
-            coordinates=point,
-            data=DataContainer(TEMPERATURE=temperature[index])))
-    uids.append(uid)
 
-for indices in bonds:
-    container.add_bond(Bond(particles=[uids[index] for index in indices]))
+# add particles
+particle_iter = (Particle(coordinates=point,
+                          data=DataContainer(TEMPERATURE=temperature[index]))
+                 for index, point in enumerate(points))
+uids = container.add_particles(particle_iter)
+
+# add bonds
+bond_iter = (Bond(particles=[uids[index] for index in indices])
+             for indices in bonds)
+container.add_bonds(bond_iter)
 
 
 # Now view the data.

--- a/examples/particles_vtk_example.py
+++ b/examples/particles_vtk_example.py
@@ -9,17 +9,17 @@ bonds = array([[0, 1], [0, 3], [1, 3, 2]])
 temperature = array([10., 20., 30., 40.])
 
 particles = mayavi_tools.VTKParticles('test')
-uids = []
-for index, point in enumerate(points):
-    uid = particles.add_particle(
-        Particle(
-            coordinates=point,
-            data=DataContainer(TEMPERATURE=temperature[index])))
-    uids.append(uid)
 
-for indices in bonds:
-    particles.add_bond(Bond(particles=[uids[index] for index in indices]))
+# add particles
+particle_iter = (Particle(coordinates=point,
+                          data=DataContainer(TEMPERATURE=temperature[index]))
+                 for index, point in enumerate(points))
+uids = particles.add_particles(particle_iter)
 
+# add bonds
+bond_iter = (Bond(particles=[uids[index] for index in indices])
+             for indices in bonds)
+particles.add_bonds(bond_iter)
 
 if __name__ == '__main__':
 

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -9,8 +9,7 @@ from simphony.core.data_container import DataContainer
 from simphony.core.cuba import CUBA
 from simphony.testing.utils import (
     compare_data_containers, compare_particles, compare_bonds,
-    create_bonds_with_id, create_bonds, create_particles_with_id,
-    create_data_container)
+    create_bonds_with_id, create_data_container)
 from simphony.testing.abc_check_particles import (
     CheckParticlesContainer,
     CheckAddingParticles, CheckManipulatingParticles,
@@ -224,18 +223,18 @@ class TestVTKParticlesDataContainer(unittest.TestCase):
         point_temperature = [10., 20., 30., 40.]
         bond_temperature = [60., 80., 190., 5.]
         reference = Particles('test')
-        point_uids = reference.add_particles((
-                Particle(
-                    coordinates=point,
-                    data=DataContainer(
-                        TEMPERATURE=point_temperature[index]))
-                for index, point in enumerate(points)))
-        bond_uids = reference.add_bonds((
-                Bond(
-                    particles=[point_uids[index] for index in indices],
-                    data=DataContainer(
-                        TEMPERATURE=bond_temperature[index]))
-                for index, indices in enumerate(bonds)))
+
+        # add particles
+        particle_iter = (Particle(coordinates=point,
+                                  data=DataContainer(TEMPERATURE=temp))
+                         for temp, point in zip(point_temperature, points))
+        point_uids = reference.add_particles(particle_iter)
+
+        # add bonds
+        bond_iter = (Bond(particles=[point_uids[index] for index in indices],
+                          data=DataContainer(TEMPERATURE=temp))
+                     for temp, indices in zip(bond_temperature, bonds))
+        bond_uids = reference.add_bonds(bond_iter)
 
         # when
         container = VTKParticles.from_particles(reference)

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -1,23 +1,26 @@
 import unittest
 from functools import partial
+import random
 
 from tvtk.api import tvtk
 from simphony.cuds.particles import Particle, Bond, Particles
 from simphony.core.data_container import DataContainer
 from simphony.core.cuba import CUBA
 from simphony.testing.utils import (
-    compare_data_containers, compare_particles, compare_bonds)
+    compare_data_containers, compare_particles, compare_bonds,
+    create_bonds_with_id, create_data_container)
 from simphony.testing.abc_check_particles import (
-    ContainerManipulatingBondsCheck, ContainerAddParticlesCheck,
-    ContainerAddBondsCheck, ContainerManipulatingParticlesCheck)
+    CheckParticlesContainer,
+    CheckAddingParticles, CheckManipulatingParticles,
+    CheckAddingBonds, CheckManipulatingBonds)
 
 from simphony_mayavi.cuds.api import VTKParticles
 from simphony_mayavi.core.api import (
     supported_cuba, VTKEDGETYPES, VTKFACETYPES)
 
 
-class TestVTKParticlesParticleOperations(
-        ContainerAddParticlesCheck, unittest.TestCase):
+class TestVTKParticlesAddingParticlesOperations(
+        CheckAddingParticles, unittest.TestCase):
 
     def supported_cuba(self):
         return supported_cuba()
@@ -27,7 +30,7 @@ class TestVTKParticlesParticleOperations(
 
 
 class TestVTKParticlesManipulatingParticles(
-        ContainerManipulatingParticlesCheck, unittest.TestCase):
+        CheckManipulatingParticles, unittest.TestCase):
 
     def supported_cuba(self):
         return supported_cuba()
@@ -36,8 +39,8 @@ class TestVTKParticlesManipulatingParticles(
         return VTKParticles(name=name)
 
 
-class TestVTKParticlesAddBonds(
-        ContainerAddBondsCheck, unittest.TestCase):
+class TestVTKParticlesAddingBonds(
+        CheckAddingBonds, unittest.TestCase):
 
     def container_factory(self, name):
         return VTKParticles(name=name)
@@ -47,7 +50,16 @@ class TestVTKParticlesAddBonds(
 
 
 class TestVTKParticlesManipulatingBonds(
-        ContainerManipulatingBondsCheck, unittest.TestCase):
+        CheckManipulatingBonds, unittest.TestCase):
+
+    def container_factory(self, name):
+        return VTKParticles(name=name)
+
+    def supported_cuba(self):
+        return supported_cuba()
+
+
+class TestVTKParticlesContainer(CheckParticlesContainer, unittest.TestCase):
 
     def container_factory(self, name):
         return VTKParticles(name=name)

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -179,7 +179,7 @@ class TestVTKParticlesContainer(CheckParticlesContainer, unittest.TestCase):
         return VTKParticles(name=name)
 
     def supported_cuba(self):
-        return supported_cuba()
+        return set(CUBA)
 
 
 class TestVTKParticlesDataContainer(unittest.TestCase):
@@ -210,7 +210,7 @@ class TestVTKParticlesDataContainer(unittest.TestCase):
         data_set = tvtk.PolyData(points=tvtk.Points(), lines=[])
         container = VTKParticles(name='test', data_set=data_set)
         particle = Particle(coordinates=(0.0, 1.0, 2.0), data=DataContainer())
-        uid = container.add_particle(particle)
+        uid = container.add_particles((particle,))[0]
         self.assertTrue(container.has_particle(uid))
         self.assertEqual(list(container.iter_bonds()), [])
         self.assertEqual(len(tuple(container.iter_particles())), 1)
@@ -224,20 +224,18 @@ class TestVTKParticlesDataContainer(unittest.TestCase):
         point_temperature = [10., 20., 30., 40.]
         bond_temperature = [60., 80., 190., 5.]
         reference = Particles('test')
-        point_uids = [
-            reference.add_particle(
+        point_uids = reference.add_particles((
                 Particle(
                     coordinates=point,
                     data=DataContainer(
-                        TEMPERATURE=point_temperature[index])))
-            for index, point in enumerate(points)]
-        bond_uids = [
-            reference.add_bond(
+                        TEMPERATURE=point_temperature[index]))
+                for index, point in enumerate(points)))
+        bond_uids = reference.add_bonds((
                 Bond(
                     particles=[point_uids[index] for index in indices],
                     data=DataContainer(
-                        TEMPERATURE=bond_temperature[index])))
-            for index, indices in enumerate(bonds)]
+                        TEMPERATURE=bond_temperature[index]))
+                for index, indices in enumerate(bonds)))
 
         # when
         container = VTKParticles.from_particles(reference)

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -8,7 +8,8 @@ from simphony.core.data_container import DataContainer
 from simphony.core.cuba import CUBA
 from simphony.testing.utils import (
     compare_data_containers, compare_particles, compare_bonds,
-    create_bonds_with_id, create_data_container)
+    create_bonds_with_id, create_particles_with_id,
+    create_data_container)
 from simphony.testing.abc_check_particles import (
     CheckParticlesContainer,
     CheckAddingParticles, CheckManipulatingParticles,
@@ -92,6 +93,34 @@ class TestVTKParticlesAddingBonds(
             self.assertTrue(container.has_bond(uid))
             self.assertEqual(container.get_bond(uid), bond)
 
+    def test_exception_when_adding_multiple_invalid_bonds(self):
+        # new test for adding bonds with particles that are
+        # not part of the container
+        # (proposed to throw ValueError, see wiki)
+
+        # given
+        container = self.container
+        bonds = create_bonds_with_id()
+
+        with self.assertRaises(ValueError):
+            container.add_bonds(bonds)
+
+
+    def test_exception_when_updating_invalid_bond(self):
+        # new test for adding bonds with particles that are
+        # not part of the container
+        # (proposed to throw ValueError, see wiki)
+
+        # given
+        container = self.container
+        new_particles = create_particles_with_id()
+
+        # when
+        bond = container.get_bond(self.ids[1])
+        bond.particles = new_particles
+
+        with self.assertRaises(ValueError):
+            container.update_bonds([bond])
 
 
 class TestVTKParticlesManipulatingBonds(

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -48,6 +48,51 @@ class TestVTKParticlesAddingBonds(
     def supported_cuba(self):
         return supported_cuba()
 
+    def test_add_multiple_bonds_with_id(self):
+        # for simphony-common 0.2.1 when Bond can be added
+        # even if it contains particles that are not part of
+        # the container (proposed to throw ValueError, see wiki)
+
+        # given
+        container = self.container
+        bonds = create_bonds_with_id(particles=self.particle_list)
+
+        # when
+        uids = container.add_bonds(bonds)
+
+        # then
+        for bond in bonds:
+            uid = bond.uid
+            self.assertIn(uid, uids)
+            self.assertTrue(container.has_bond(uid))
+            self.assertEqual(container.get_bond(uid), bond)
+
+    def test_add_multiple_bonds_with_unsupported_cuba(self):
+        # for simphony-common 0.2.1 when Bond can be added
+        # even if it contains particles that are not part of
+        # the container (proposed to throw ValueError, see wiki)
+
+        # given
+        container = self.container
+        bonds = []
+        particle_ids = [particle.uid for particle in self.particle_list]
+        for i in xrange(5):
+            data = create_data_container()
+            ids = random.sample(particle_ids, 5)
+            bonds.append(Bond(particles=ids, data=data))
+
+        # when
+        container.add_bonds(bonds)
+
+        # then
+        for bond in bonds:
+            bond.data = create_data_container(
+                restrict=self.supported_cuba())
+            uid = bond.uid
+            self.assertTrue(container.has_bond(uid))
+            self.assertEqual(container.get_bond(uid), bond)
+
+
 
 class TestVTKParticlesManipulatingBonds(
         CheckManipulatingBonds, unittest.TestCase):

--- a/simphony_mayavi/cuds/tests/test_vtk_particles.py
+++ b/simphony_mayavi/cuds/tests/test_vtk_particles.py
@@ -163,24 +163,14 @@ class TestVTKParticlesManipulatingBonds(
 
         # given
         container = self.container
-        new_particles = create_particles_with_id()
+        new_ids = [uuid.uuid4() for x in xrange(5)]
 
         # when
         bond = container.get_bond(self.ids[1])
-        bond.particles = new_particles
+        bond.particles = new_ids
 
         with self.assertRaises(ValueError):
             container.update_bonds([bond])
-
-
-class TestVTKParticlesManipulatingBonds(
-        CheckManipulatingBonds, unittest.TestCase):
-
-    def container_factory(self, name):
-        return VTKParticles(name=name)
-
-    def supported_cuba(self):
-        return supported_cuba()
 
 
 class TestVTKParticlesContainer(CheckParticlesContainer, unittest.TestCase):

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -407,7 +407,7 @@ class VTKParticles(ABCParticles):
             raise ValueError(message.format(item.uid))
         elif not isinstance(item.uid, uuid.UUID):
             message = "{!r} has an invalid uid: {}"
-            raise AttributeError(message.format(item, item))
+            raise AttributeError(message.format(item, item.uid))
         yield item
 
     def _swap_with_last(self, uid, mapping, reverse_mapping, items, data):

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -4,7 +4,6 @@ import contextlib
 
 from tvtk.api import tvtk
 
-from simphony.core.cuba import CUBA
 from simphony.cuds.abc_particles import ABCParticles
 from simphony.core.cuds_item import CUDSItem
 from simphony.cuds.particles import Particle, Bond
@@ -232,7 +231,7 @@ class VTKParticles(ABCParticles):
         # for points.to_array() to work properly
         _array_cache = None
         for name in ['array_handler', 'tvtk.array_handler']:
-            if sys.modules.has_key(name):
+            if name in sys.modules:
                 mod = sys.modules[name]
                 if hasattr(mod, '_array_cache'):
                     _array_cache = mod._array_cache
@@ -324,7 +323,8 @@ class VTKParticles(ABCParticles):
                 if not self.is_connected(bond):
                     message = "Cannot add Bond {} with missing uids: {}"
                     raise ValueError(message.format(item.uid, item.particles))
-                point_ids = [self.particle2index[uid] for uid in item.particles]
+                point_ids = [self.particle2index[uid]
+                             for uid in item.particles]
                 index = data_set.insert_next_cell(VTKEDGETYPES[1], point_ids)
                 bond2index[item.uid] = index
                 self.index2bond[index] = item.uid

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -254,11 +254,8 @@ class VTKParticles(ABCParticles):
         points = self.data_set.points
         point_data = self.point_data
 
-        # keep a counter in case uids is a generator
-        # it is used for resizing data_set.points in batch
-        count = 0
-
-        for uid in uids:
+        # `count` is used for resizing data_set.points in batch
+        for count, uid in enumerate(uids, start=1):
             # move uid item to the end
             self._swap_with_last(
                 uid, particle2index, index2particle,
@@ -271,7 +268,6 @@ class VTKParticles(ABCParticles):
             # remove uid item from mappings
             del particle2index[uid]
             del index2particle[index]
-            count += 1
 
         array = points.to_array()
         self.data_set.points = array[:-count]

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -278,7 +278,7 @@ class VTKParticles(ABCParticles):
             try:
                 index = self.particle2index[particle.uid]
             except KeyError:
-                message = "Particle with {} does exist"
+                message = "Particle with {} does not exist"
                 raise ValueError(message.format(particle.uid))
             self.data_set.points[index] = particle.coordinates
             self.point_data[index] = particle.data

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -405,6 +405,9 @@ class VTKParticles(ABCParticles):
         elif item.uid in container:
             message = "Item with id:{} already exists"
             raise ValueError(message.format(item.uid))
+        elif not isinstance(item.uid, uuid.UUID):
+            message = "{!r} has an invalid uid: {}"
+            raise AttributeError(message.format(item, item))
         yield item
 
     def _swap_with_last(self, uid, mapping, reverse_mapping, items, data):

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -323,8 +323,7 @@ class VTKParticles(ABCParticles):
             with self._add_item(bond, bond2index) as item:
                 if not self.is_connected(bond):
                     message = "Cannot add Bond {} with missing uids: {}"
-                    raise ValueError(message.format(bond.uid if bond.uid else "",
-                                                    bond.particles))
+                    raise ValueError(message.format(item.uid, item.particles))
                 point_ids = [self.particle2index[uid] for uid in item.particles]
                 index = data_set.insert_next_cell(VTKEDGETYPES[1], point_ids)
                 bond2index[item.uid] = index

--- a/simphony_mayavi/cuds/vtk_particles.py
+++ b/simphony_mayavi/cuds/vtk_particles.py
@@ -334,10 +334,14 @@ class VTKParticles(ABCParticles):
 
     def get_bond(self, uid):
         index = self.bond2index[uid]
-        line = self.data_set.get_cell(index)
+
+        # cannot use self.data_set.get_cell(index) here because
+        # get_cell would give the wrong point_ids if the dimension
+        # of the cell changes upon update
+        point_ids = self.bonds[index]
         return Bond(
             uid=uid,
-            particles=[self.index2particle[i] for i in line.point_ids],
+            particles=[self.index2particle[i] for i in point_ids],
             data=self.bond_data[index])
 
     def update_bonds(self, bonds):

--- a/simphony_mayavi/sources/cuds_file_source.py
+++ b/simphony_mayavi/sources/cuds_file_source.py
@@ -60,8 +60,8 @@ class CUDSFileSource(CUDSSource):
         with closing(H5CUDS.open(str(self.file_path))) as handle:
             try:
                 self.cuds = handle.get_dataset(dataset)
-            except ValueError as ex:
-                logger.warning(ex.message)
+            except ValueError as exception:
+                logger.warning(exception.message)
 
     # Trait Change Handlers ################################################
 

--- a/simphony_mayavi/sources/tests/test_cuds_file_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_file_source.py
@@ -9,7 +9,7 @@ from tvtk.api import tvtk
 from mayavi.core.api import NullEngine
 from simphony.cuds.particles import Particles
 from simphony.cuds.mesh import Mesh
-from simphony.cuds.lattice import Lattice
+from simphony.cuds.lattice import Lattice, make_cubic_lattice
 from simphony.io.h5_cuds import H5CUDS
 from simphony.io.h5_lattice import H5Lattice
 from simphony.io.h5_mesh import H5Mesh
@@ -26,12 +26,11 @@ class TestLatticeSource(unittest.TestCase, UnittestTools):
         self.maxDiff = None
         self.filename = os.path.join(self.temp_dir, 'test.cuds')
         with closing(H5CUDS.open(self.filename, mode='w')) as handle:
-            handle.add_mesh(Mesh(name='mesh1'))
-            handle.add_particles(Particles(name='particles1'))
-            handle.add_particles(Particles(name='particles3'))
-            handle.add_lattice(Lattice(
-                'lattice0', 'Cubic', (0.2, 0.2, 0.2),
-                (5, 10, 15), (0.0, 0.0, 0.0)))
+            handle.add_dataset(Mesh(name='mesh1'))
+            handle.add_dataset(Particles(name='particles1'))
+            handle.add_dataset(Particles(name='particles3'))
+            handle.add_dataset(make_cubic_lattice(
+                'lattice0', 0.2, (5, 10, 15), (0.0, 0.0, 0.0)))
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/simphony_mayavi/sources/tests/test_cuds_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_source.py
@@ -348,18 +348,21 @@ class TestParticlesSource(unittest.TestCase):
         self.container = Particles('test')
 
         # add particles
-        self.point_uids = self.container.add_particles(
-            (Particle(coordinates=point,
-                      data=DataContainer(
-                                  TEMPERATURE=self.point_temperature[index]))
-             for index, point in enumerate(self.points)))
+        def particle_iter():
+            for temp, point in zip(self.point_temperature, self.points):
+                yield Particle(coordinates=point,
+                               data=DataContainer(TEMPERATURE=temp))
+
+        self.point_uids = self.container.add_particles(particle_iter())
 
         # add bonds
-        self.bond_uids = self.container.add_bonds(
-                (Bond(particles=[self.point_uids[index] for index in indices],
-                      data=DataContainer(
-                                  TEMPERATURE=self.bond_temperature[index]))
-                 for index, indices in enumerate(self.bonds)))
+        def bond_iter():
+            for temp, indices in zip(self.bond_temperature, self.bonds):
+                yield Bond(particles=[self.point_uids[index]
+                                      for index in indices],
+                           data=DataContainer(TEMPERATURE=temp))
+
+        self.bond_uids = self.container.add_bonds(bond_iter())
 
     def test_source_from_vtk_particles(self):
         # given

--- a/simphony_mayavi/sources/tests/test_cuds_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_source.py
@@ -346,28 +346,26 @@ class TestParticlesSource(unittest.TestCase):
         self.bond_temperature = [60., 80., 190., 5.]
 
         self.container = Particles('test')
-        self.point_uids = [
-            self.container.add_particle(
-                Particle(
-                    coordinates=point,
-                    data=DataContainer(
-                        TEMPERATURE=self.point_temperature[index])))
-            for index, point in enumerate(self.points)]
-        self.bond_uids = [
-            self.container.add_bond(
-                Bond(
-                    particles=[self.point_uids[index] for index in indices],
-                    data=DataContainer(
-                        TEMPERATURE=self.bond_temperature[index])))
-            for index, indices in enumerate(self.bonds)]
+
+        # add particles
+        self.point_uids = self.container.add_particles(
+            (Particle(coordinates=point,
+                      data=DataContainer(
+                                  TEMPERATURE=self.point_temperature[index]))
+             for index, point in enumerate(self.points)))
+
+        # add bonds
+        self.bond_uids = self.container.add_bonds(
+                (Bond(particles=[self.point_uids[index] for index in indices],
+                      data=DataContainer(
+                                  TEMPERATURE=self.bond_temperature[index]))
+                 for index, indices in enumerate(self.bonds)))
 
     def test_source_from_vtk_particles(self):
         # given
         container = VTKParticles('test')
-        for particle in self.container.iter_particles():
-            container.add_particle(particle)
-        for bond in self.container.iter_bonds():
-            container.add_bond(bond)
+        container.add_particles(self.container.iter_particles())
+        container.add_bonds(self.container.iter_bonds())
 
         # when
         source = CUDSSource(cuds=container)

--- a/simphony_mayavi/tests/test_show.py
+++ b/simphony_mayavi/tests/test_show.py
@@ -51,8 +51,9 @@ class TestShow(unittest.TestCase, GuiTestAssistant):
             [2, 0, 1], [3, 0, 1], [3, 1, 1], [2, 1, 1]],
             'f')
         particles = Particles('test')
-        for index, point in enumerate(coordinates):
-            particles.add_particle(Particle(coordinates=point + 3))
+        particle_iter = (Particle(coordinates=point+3)
+                         for point in coordinates)
+        particles.add_particles(particle_iter)
 
         def function():
             show(particles)

--- a/simphony_mayavi/tests/test_snapshot.py
+++ b/simphony_mayavi/tests/test_snapshot.py
@@ -52,8 +52,9 @@ class TestSnapShot(unittest.TestCase):
             [2, 0, 1], [3, 0, 1], [3, 1, 1], [2, 1, 1]],
             'f')
         particles = Particles('test')
-        for index, point in enumerate(coordinates):
-            particles.add_particle(Particle(coordinates=point + 3))
+        particle_iter = (Particle(coordinates=point+3)
+                         for point in coordinates)
+        particles.add_particles(particle_iter)
 
         snapshot(particles, filename)
         self.assertImageSavedWithContent(filename)


### PR DESCRIPTION
I have fixed support for vtk-particle.  Please take a look @dpinte, @itziakos.
Now the failed tests are the ones that have to do with H5CUDS.

Note:
I have implemented the [proposal regarding adding/updating bonds that contain particles outside of the particles container](https://publicwiki-01.fraunhofer.de/SimPhoNy-Project/index.php/Operations_on_Bonds_and_other_connectivity_objects) in `vtk_particle`.  ValueError would be raised if the user tries to do so.  Since the simphony-common has not implemented this proposal, I have overloaded and added tests in `simphony_mayavi.cuds.tests.test_vtk_particles`
