### PR TITLE
Upgrade h5cuds support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 - mayavi[app] >= 4.4.0
-- simphony[H5IO] == 0.1.5
+- simphony[H5IO] == 0.2.1
 
 Optional requirements
 ~~~~~~~~~~~~~~~~~~~~~

--- a/simphony_mayavi/sources/cuds_file_source.py
+++ b/simphony_mayavi/sources/cuds_file_source.py
@@ -60,8 +60,8 @@ class CUDSFileSource(CUDSSource):
         with closing(H5CUDS.open(str(self.file_path))) as handle:
             try:
                 self.cuds = handle.get_dataset(dataset)
-            except ValueError as ex:
-                logger.warning(ex.message)
+            except ValueError as exception:
+                logger.warning(exception.message)
 
     # Trait Change Handlers ################################################
 

--- a/simphony_mayavi/sources/tests/test_cuds_file_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_file_source.py
@@ -9,7 +9,7 @@ from tvtk.api import tvtk
 from mayavi.core.api import NullEngine
 from simphony.cuds.particles import Particles
 from simphony.cuds.mesh import Mesh
-from simphony.cuds.lattice import Lattice
+from simphony.cuds.lattice import Lattice, make_cubic_lattice
 from simphony.io.h5_cuds import H5CUDS
 from simphony.io.h5_lattice import H5Lattice
 from simphony.io.h5_mesh import H5Mesh
@@ -26,12 +26,11 @@ class TestLatticeSource(unittest.TestCase, UnittestTools):
         self.maxDiff = None
         self.filename = os.path.join(self.temp_dir, 'test.cuds')
         with closing(H5CUDS.open(self.filename, mode='w')) as handle:
-            handle.add_mesh(Mesh(name='mesh1'))
-            handle.add_particles(Particles(name='particles1'))
-            handle.add_particles(Particles(name='particles3'))
-            handle.add_lattice(Lattice(
-                'lattice0', 'Cubic', (0.2, 0.2, 0.2),
-                (5, 10, 15), (0.0, 0.0, 0.0)))
+            handle.add_dataset(Mesh(name='mesh1'))
+            handle.add_dataset(Particles(name='particles1'))
+            handle.add_dataset(Particles(name='particles3'))
+            handle.add_dataset(make_cubic_lattice(
+                'lattice0', 0.2, (5, 10, 15), (0.0, 0.0, 0.0)))
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)


### PR DESCRIPTION
Comparisons shown here are between this branch and `upgrade-particle-support`

Travis CI build is successful.

Next steps:
- coverage fell from 96.2% to 92.6%.  More tests need to be added.
- lattice_vtk_example should show a cubic lattice
- some functions parameters are not consistent with the docstring merged from the abstract base classes; this leads to inconsistency in the documentation
- other opened issues
