### PR TITLE
use numpy dtype for checking default cuba value

### DIFF
--- a/simphony_mayavi/core/cuba_data_accumulator.py
+++ b/simphony_mayavi/core/cuba_data_accumulator.py
@@ -130,7 +130,8 @@ class CUBADataAccumulator(object):
 
         for cuba in self.keys:
             default = dummy_cuba_value(cuba)
-            if isinstance(default, (float, int)):
+            if (numpy.issubdtype(type(default), numpy.float) or
+                    numpy.issubdtype(type(default), numpy.int)):
                 data = numpy.array(self._data[cuba], dtype=float)
                 index = vtk_data.add_array(data)
                 vtk_data.get_array(index).name = cuba.name


### PR DESCRIPTION
@dpinte 
This follows the changes I made in `simphony-common`: https://github.com/simphony/simphony-common/commit/e079a475e239616b21eb60ac2701d9c8c82b9aad
