### PR TITLE
default_module: add a glyph module even if no scalar/vector data

### DIFF
--- a/simphony_mayavi/modules/default_module.py
+++ b/simphony_mayavi/modules/default_module.py
@@ -84,4 +84,4 @@ def default_module(source):
     else:
         message = "Unknown scalar/vector data for setting default module"
         logger.warning(message)
-        return []
+        return [default_scalar_module(scale_factor)]

--- a/simphony_mayavi/modules/tests/test_default_module.py
+++ b/simphony_mayavi/modules/tests/test_default_module.py
@@ -225,3 +225,16 @@ class TestDefaultModule(unittest.TestCase):
         self.assertEqual(sum((isinstance(module, Surface)
                               for module in modules)),
                          2, message.format(data_names, modules))
+
+    def test_default_module_empty_data(self):
+        # given
+        lattice = make_cubic_lattice("test", 0.2, (10, 10, 1))
+        source = CUDSSource(cuds=lattice)
+
+        # when
+        modules = default_module(source)
+
+        # then
+        # one Glyph as default when no data is found
+        self.assertEqual(len(modules), 1)
+        self.assertIsInstance(modules[0], Glyph)


### PR DESCRIPTION
It was my mistake to add no module at all if there is no scalar/vector data.  It would be helpful to at least see grey points even if the points have no data.
