### PR TITLE
Use Pillow instead of PIL

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,4 @@
---allow-external PIL
---allow-unverified PIL
-PIL
+Pillow
 coverage
 flake8
 


### PR DESCRIPTION
`pip install --allow-external PIL --allow-unverified PIL PIL` does not work anymore.
Previous build successes relied on site packages with PIL already installed.
