### PR TITLE
RunAndAnimate fails when there is non-EngineSource in scene

### DIFF
--- a/simphony_mayavi/plugins/run_and_animate.py
+++ b/simphony_mayavi/plugins/run_and_animate.py
@@ -138,7 +138,8 @@ class RunAndAnimate(object):
         '''
         sources = self.mayavi_engine.current_scene.children
         return {source for source in sources
-                if source.engine == self.engine}
+                if (hasattr(source, "engine") and
+                    source.engine == self.engine)}
 
     def _get_all_sources(self):
         ''' Return sources from all the scenes and that the sources
@@ -151,5 +152,6 @@ class RunAndAnimate(object):
         sources = {source
                    for scene in self.mayavi_engine.scenes
                    for source in scene.children
-                   if source.engine == self.engine}
+                   if (hasattr(source, "engine") and
+                       source.engine == self.engine)}
         return sources

--- a/simphony_mayavi/plugins/tests/test_run_and_animate_panel.py
+++ b/simphony_mayavi/plugins/tests/test_run_and_animate_panel.py
@@ -1,6 +1,7 @@
 import unittest
 
 from mayavi.core.api import NullEngine
+from mayavi.sources.vtk_data_source import VTKDataSource
 
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from pyface.ui.qt4.util.modal_dialog_tester import ModalDialogTester
@@ -82,6 +83,7 @@ class TestRunAndAnimatePanel(GuiTestAssistant, unittest.TestCase):
         # given
         self._setUp()
         self.panel.engine = testing_utils.DummyEngine()
+        self.panel.mayavi_engine.add_source(VTKDataSource())
 
         # when
         def animate():


### PR DESCRIPTION
When `simphony_mayavi.plugins.run_and_animate`looks for sources that belong to the engine wrapper, it wrongly assumes the vtk datasource must have an attribute `engine`.  Fails as soon as there are other stuff in the scene not using `EngineSource`.
