### PR TITLE
need to use the manager's attribute ref for engine/engine_name in panels

### DIFF
--- a/simphony_mayavi/plugins/engine_manager_standalone_ui.py
+++ b/simphony_mayavi/plugins/engine_manager_standalone_ui.py
@@ -51,10 +51,10 @@ class EngineManagerStandaloneUI(EngineManager):
         # Add panels
         self.panels = TabbedPanelCollection.create(
             add_engine=AddEnginePanel(engine_manager=self),
-            add_source=AddSourcePanel(engine_name=engine_name,
-                                      engine=engine,
+            add_source=AddSourcePanel(engine_name=self.engine_name,
+                                      engine=self.engine,
                                       mayavi_engine=mayavi_engine),
-            run_and_animate=RunAndAnimatePanel(engine=engine,
+            run_and_animate=RunAndAnimatePanel(engine=self.engine,
                                                mayavi_engine=mayavi_engine))
 
         if engine and engine_name:

--- a/simphony_mayavi/plugins/tests/test_engine_manager_standalone_ui.py
+++ b/simphony_mayavi/plugins/tests/test_engine_manager_standalone_ui.py
@@ -18,6 +18,15 @@ class TestEngineManagerStandaloneUI(UnittestTools, unittest.TestCase):
         self.assertIs(manager.engine, None)
         self.assertEqual(manager.engines, {})
 
+    def test_init_no_engine_then_add_engine(self):
+        manager = EngineManagerStandaloneUI()
+        engine = testing_utils.DummyEngine()
+        manager.add_engine("test", engine)
+
+        for panel in manager.panels:
+            if hasattr(panel, "engine"):
+                self.assertEqual(panel.engine, engine)
+
     def test_init_default_mayavi_engine(self):
         # given
         engine = testing_utils.DummyEngine()


### PR DESCRIPTION
If the `EngineManagerStandaloneUI` is first initialised to have no engine and then have the first engine added later, `engine_name`(`DEnum`) does not fire a `_engine_name_changed` event and the panels do not synchronise to use the new engine.  With the reference to the manager's attribute assigned instead, this bug is fixed.

```
from simphony.visualisation import mayavi_tools
gui = mayavi_tools.EngineManagerStandaloneUI()   # initialised to be empty
gui.add_engine(...)  # the panels won't know about this when the first engine is added
```
