### PR TITLE
Travis CI: should not allow failure for common 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ virtualenv:
   system_site_packages: true
 env:
   - SIMPHONY_VERSION=master
+  - SIMPHONY_VERSION=0.3.0
+  - SIMPHONY_VERSION=0.2.2
 matrix:
   allow_failures:
     - env: SIMPHONY_VERSION=master
+    - env: SIMPHONY_VERSION=0.2.2
 addons:
   apt:
     packages:


### PR DESCRIPTION
That's why Travis CI never fails!
Fix #133 
