### PR TITLE
Replace load from py with Mayavi2 RunScript

### DIFF
--- a/examples/krato-cfd-example.py
+++ b/examples/krato-cfd-example.py
@@ -45,3 +45,6 @@ for mesh in kratos_model['meshes']:
 for bc in kratos_model['bcs']:
     wrapper.BC[CUBA.VELOCITY][bc['name']] = bc['velocity']
     wrapper.BC[CUBA.PRESSURE][bc['name']] = bc['pressure']
+
+from simphony.visualisation import mayavi_tools
+mayavi_tools.add_engine_to_mayavi2("kratos", wrapper)

--- a/examples/krato-cfd-example.py
+++ b/examples/krato-cfd-example.py
@@ -2,6 +2,8 @@
 """
 import os
 
+from mayavi.scripts import mayavi2
+
 from simphony.core.cuba import CUBA
 from simphony.engine import kratos
 
@@ -48,4 +50,11 @@ for bc in kratos_model['bcs']:
     wrapper.BC[CUBA.VELOCITY][bc['name']] = bc['velocity']
     wrapper.BC[CUBA.PRESSURE][bc['name']] = bc['pressure']
 
-mayavi_tools.add_engine_to_mayavi2("kratos", wrapper)
+
+@mayavi2.standalone
+def view():
+    mayavi_tools.add_engine_to_mayavi2("kratos", wrapper)
+
+
+if __name__ == "__main__":
+    view()

--- a/examples/krato-cfd-example.py
+++ b/examples/krato-cfd-example.py
@@ -11,6 +11,8 @@ from KratosMultiphysics.FluidDynamicsApplication import *
 from KratosMultiphysics.ExternalSolversApplication import *
 from KratosMultiphysics.MeshingApplication import *
 
+from simphony.visualisation import mayavi_tools
+
 
 path = str(os.path.join(
     os.path.dirname(__file__),
@@ -46,5 +48,4 @@ for bc in kratos_model['bcs']:
     wrapper.BC[CUBA.VELOCITY][bc['name']] = bc['velocity']
     wrapper.BC[CUBA.PRESSURE][bc['name']] = bc['pressure']
 
-from simphony.visualisation import mayavi_tools
 mayavi_tools.add_engine_to_mayavi2("kratos", wrapper)

--- a/examples/lammps_engine_example.py
+++ b/examples/lammps_engine_example.py
@@ -8,6 +8,7 @@ from simphony.engine import lammps
 
 from simlammps import EngineType
 from simphony.core.cuba import CUBA
+from simphony.visualisation import mayavi_tools
 
 # read data
 particles = lammps.read_data_file(
@@ -33,5 +34,4 @@ dem.add_dataset(particles)
 # Run the engine
 dem.run()
 
-from simphony.visualisation import mayavi_tools
 mayavi_tools.add_engine_to_mayavi2("lammps", dem)

--- a/examples/lammps_engine_example.py
+++ b/examples/lammps_engine_example.py
@@ -4,8 +4,9 @@ github.com/simphony/simphony-lammps-md/examples/dem_billiards/billiards_init.dat
 """
 import os
 
-from simphony.engine import lammps
+from mayavi.scripts import mayavi2
 
+from simphony.engine import lammps
 from simlammps import EngineType
 from simphony.core.cuba import CUBA
 from simphony.visualisation import mayavi_tools
@@ -34,4 +35,11 @@ dem.add_dataset(particles)
 # Run the engine
 dem.run()
 
-mayavi_tools.add_engine_to_mayavi2("lammps", dem)
+
+@mayavi2.standalone
+def view():
+    mayavi_tools.add_engine_to_mayavi2("lammps", dem)
+
+
+if __name__ == "__main__":
+    view()

--- a/examples/lammps_engine_example.py
+++ b/examples/lammps_engine_example.py
@@ -32,3 +32,6 @@ dem.add_dataset(particles)
 
 # Run the engine
 dem.run()
+
+from simphony.visualisation import mayavi_tools
+mayavi_tools.add_engine_to_mayavi2("lammps", dem)

--- a/simphony_mayavi/api.py
+++ b/simphony_mayavi/api.py
@@ -2,8 +2,7 @@ from .show import show
 from .snapshot import snapshot
 from .adapt2cuds import adapt2cuds
 from .load import load
-from .get_mayavi2_engine_manager import (get_mayavi2_engine_manager,
-                                         add_engine_to_mayavi2)
+from .get_mayavi2_engine_manager import add_engine_to_mayavi2
 
 __all__ = ['show', 'snapshot', 'adapt2cuds', 'load',
-           'get_mayavi2_engine_manager', 'add_engine_to_mayavi2']
+           'add_engine_to_mayavi2']

--- a/simphony_mayavi/api.py
+++ b/simphony_mayavi/api.py
@@ -2,5 +2,8 @@ from .show import show
 from .snapshot import snapshot
 from .adapt2cuds import adapt2cuds
 from .load import load
+from .get_mayavi2_engine_manager import (get_mayavi2_engine_manager,
+                                         add_engine_to_mayavi2)
 
-__all__ = ['show', 'snapshot', 'adapt2cuds', 'load']
+__all__ = ['show', 'snapshot', 'adapt2cuds', 'load',
+           'get_mayavi2_engine_manager', 'add_engine_to_mayavi2']

--- a/simphony_mayavi/get_mayavi2_engine_manager.py
+++ b/simphony_mayavi/get_mayavi2_engine_manager.py
@@ -1,0 +1,24 @@
+from mayavi import mlab
+
+def get_mayavi2_engine_manager():
+    ''' Return the EngineManager panel sitting in Mayavi2'''
+    window = mlab.get_engine().window
+    return window.get_service("simphony_mayavi.plugins.engine_manager_mayavi2.EngineManagerMayavi2")  # noqa
+
+
+def add_engine_to_mayavi2(name, engine):
+    ''' Add an ABCModelingEngine instance to the Mayavi2 plugin for
+    SimPhoNy
+
+    Equivalent to::
+
+    mayavi_tools.get_mayavi2_engine_manager().add_engine(name, engine)
+
+    Parameters
+    ----------
+    name : str
+        Name of the Simphony Modeling Engine
+    engine : ABCModelingEngine
+        Simphony Modeling Engine
+    '''
+    get_mayavi2_engine_manager().add_engine(name, engine)

--- a/simphony_mayavi/get_mayavi2_engine_manager.py
+++ b/simphony_mayavi/get_mayavi2_engine_manager.py
@@ -1,9 +1,15 @@
 from mayavi import mlab
 
+
 def get_mayavi2_engine_manager():
     ''' Return the EngineManager panel sitting in Mayavi2'''
-    window = mlab.get_engine().window
-    return window.get_service("simphony_mayavi.plugins.engine_manager_mayavi2.EngineManagerMayavi2")  # noqa
+    panel = mlab.get_engine().window.get_service("simphony_mayavi.plugins.engine_manager_mayavi2.EngineManagerMayavi2")  # noqa
+    if panel:
+        return panel
+    else:
+        message = ("Could not locate the EngineManager contributed by "
+                   "the simphony_mayavi plugin")
+        raise ValueError(message)
 
 
 def add_engine_to_mayavi2(name, engine):

--- a/simphony_mayavi/get_mayavi2_engine_manager.py
+++ b/simphony_mayavi/get_mayavi2_engine_manager.py
@@ -3,7 +3,14 @@ from mayavi import mlab
 
 def get_mayavi2_engine_manager():
     ''' Return the EngineManager panel sitting in Mayavi2'''
-    panel = mlab.get_engine().window.get_service("simphony_mayavi.plugins.engine_manager_mayavi2.EngineManagerMayavi2")  # noqa
+    try:
+        window = mlab.get_engine().window
+    except AttributeError:
+        message = "Failed to find the application window. Is Mayavi2 running?"
+        raise AttributeError(message)
+
+    panel = window.get_service("simphony_mayavi.plugins.engine_manager_mayavi2.EngineManagerMayavi2")  # noqa
+
     if panel:
         return panel
     else:

--- a/simphony_mayavi/plugin.py
+++ b/simphony_mayavi/plugin.py
@@ -1,6 +1,5 @@
 from simphony_mayavi._version import full_version as __version__
 from simphony_mayavi.api import (show, snapshot, adapt2cuds, load,
-                                 get_mayavi2_engine_manager,
                                  add_engine_to_mayavi2)
 from simphony_mayavi.cuds.api import VTKParticles, VTKLattice, VTKMesh
 from simphony_mayavi.plugins.api import (EngineManagerStandalone,
@@ -8,7 +7,6 @@ from simphony_mayavi.plugins.api import (EngineManagerStandalone,
 
 __all__ = [
     'show', 'snapshot', 'adapt2cuds', 'load',
-    'get_mayavi2_engine_manager',
     'add_engine_to_mayavi2',
     '__version__',
     'VTKParticles', 'VTKLattice', 'VTKMesh',

--- a/simphony_mayavi/plugin.py
+++ b/simphony_mayavi/plugin.py
@@ -1,11 +1,15 @@
 from simphony_mayavi._version import full_version as __version__
-from simphony_mayavi.api import show, snapshot, adapt2cuds, load
+from simphony_mayavi.api import (show, snapshot, adapt2cuds, load,
+                                 get_mayavi2_engine_manager,
+                                 add_engine_to_mayavi2)
 from simphony_mayavi.cuds.api import VTKParticles, VTKLattice, VTKMesh
 from simphony_mayavi.plugins.api import (EngineManagerStandalone,
                                          EngineManagerStandaloneUI)
 
 __all__ = [
     'show', 'snapshot', 'adapt2cuds', 'load',
+    'get_mayavi2_engine_manager',
+    'add_engine_to_mayavi2',
     '__version__',
     'VTKParticles', 'VTKLattice', 'VTKMesh',
     'EngineManagerStandalone', 'EngineManagerStandaloneUI']

--- a/simphony_mayavi/plugins/add_engine_panel.py
+++ b/simphony_mayavi/plugins/add_engine_panel.py
@@ -1,8 +1,8 @@
 import logging
 
 from pyface.api import MessageDialog
-from traits.api import (HasTraits, File, Instance, List, Str, Event, Dict,
-                        Bool, Property, Callable)
+from traits.api import (HasTraits, Instance, List, Str, Event, Dict,
+                        Bool, Property)
 from traitsui.api import (View, Group, VGroup, HGroup, ButtonEditor, Item,
                           EnumEditor, TextEditor)
 
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 class AddEnginePanel(HasTraits):
-    ''' A panel to load a new modeling engine from a *.py file
-    or create one from a factory function.  Then send it to an
-    EngineManager instance ``engine_manager``
+    ''' A panel to add a new modeling engine by creating one from
+    a factory function. Then send it to the EngineManager instance
+    ``engine_manager``
     '''
 
     engine_manager = Instance(EngineManager, allow_none=False)
@@ -30,16 +30,6 @@ class AddEnginePanel(HasTraits):
 
     # Name of the panel
     label = "Add Engine"
-
-    # Load from a python script
-    # python script file
-    file_name = File
-
-    # Loaded local variables from the scripts
-    # List(Str) and Str for Traits EnumEditor and listener
-    loaded_variables = Dict
-    loaded_variables_names = List(Str)
-    selected_variable_name = Str
 
     # Instantiate from a factory
     factories = Dict(Str, Instance(ABCEngineFactory))
@@ -58,15 +48,6 @@ class AddEnginePanel(HasTraits):
 
     panel_view = View(
         VGroup(
-            # Load from file
-            Group(
-                Item("file_name", label="File"),
-                Item("selected_variable_name",
-                     visible_when="loaded_variables_names",
-                     label="Variable",
-                     editor=EnumEditor(name="loaded_variables_names")),
-                label="Load engine from *.py file",
-                show_border=True),
             # Load from factory
             Group(
                 Item("factory_name", show_label=False,
@@ -97,52 +78,10 @@ class AddEnginePanel(HasTraits):
                                        self.new_engine)
         self._reset_all()
 
-    def _file_name_changed(self):
-        ''' Load the python script file and pull the local variables
-        that are instances of ABCModelingEngine '''
-
-        if self.file_name is None or self.file_name == "":
-            return
-
-        # Error if the file is not a *py file
-        if not self.file_name.endswith(".py"):
-            self._display_message("Not a *.py file")
-            self._reset_load_file_panel()
-            return
-
-        # Try to exec the python file
-        try:
-            local_vars = self._exec_python_file(self.file_name)
-        except Exception as exception:
-            self._display_message(exception.message)
-            self._reset_load_file_panel()
-        else:
-            # The python script is loaded successfully
-            # only keep the local variables that are
-            # instances of ABCModelingEngine
-            self.loaded_variables = {name: value
-                                     for name, value in local_vars.items()
-                                     if isinstance(value, ABCModelingEngine)}
-            self.loaded_variables_names = self.loaded_variables.keys()
-
-            # None of the loaded local variables is ABCModelingEngine
-            if len(self.loaded_variables_names) == 0:
-                self._display_message("No instance of ABCModelingEngine found")
-                self._reset_load_file_panel()
-
-    def _reset_load_file_panel(self):
-        ''' Reset all inputs and variables for loading from file
-        '''
-        self.file_name = ""
-        self.loaded_variables_names = []
-        self.loaded_variables = {}
-        self.selected_variable_name = ""
-
     def _reset_create_from_factory_panel(self):
         self.factory_name = ""
 
     def _reset_all(self):
-        self._reset_load_file_panel()
         self._reset_create_from_factory_panel()
         self.new_engine_name = ""
         self.new_engine = None
@@ -158,22 +97,6 @@ class AddEnginePanel(HasTraits):
         getattr(message_dialog, mode)(message)
         getattr(logger, mode)(message)
 
-    def _exec_python_file(self, file_name):
-        ''' Execute the python script and return only the local variables
-
-        Returns
-        -------
-        local_vars : dict
-        '''
-        global_vars = {}
-        local_vars = {}
-        with open(file_name, "r") as file_obj:
-            # scripts often need __file__ to identify the path
-            # for reading external data
-            global_vars["__file__"] = file_obj.name
-            exec(file_obj, global_vars, local_vars)
-        return local_vars
-
     # ------------------------------------------------------
     # Handlers for TraitsUI
     # ------------------------------------------------------
@@ -181,8 +104,7 @@ class AddEnginePanel(HasTraits):
     def _factory_name_changed(self):
         ''' Use selected factory for creating a new engine
         and assign the engine to self.new_engine
-        If the factory_name is unselected and no engine is defined by
-        loading a file, set new_engine to None'''
+        '''
         if self.factory_name:
             # engine factory selected
             factory = self.factories[self.factory_name]
@@ -197,23 +119,8 @@ class AddEnginePanel(HasTraits):
             except Exception as exception:
                 self._display_message(exception.message)
                 self.new_engine = None
-
-            # reset the load-file panel
-            self._reset_load_file_panel()
-
-        elif not self.selected_variable_name:
+        else:
             self.new_engine = None
-            self._reset_load_file_panel()
-
-    def _selected_variable_name_changed(self):
-        ''' Set self.new_engine to the local variable loaded and selected
-        '''
-        if self.selected_variable_name:
-            key = self.selected_variable_name
-            self.new_engine = self.loaded_variables[key]
-            # new_engine is modified, anything in the
-            # 'create from factory' section is irrelevant now
-            self._reset_create_from_factory_panel()
 
     def _get_status(self):
         ''' Message to tell the user what is wrong with the inputs'''

--- a/simphony_mayavi/plugins/tests/test_add_engine_panel.py
+++ b/simphony_mayavi/plugins/tests/test_add_engine_panel.py
@@ -1,7 +1,4 @@
-import os
 import unittest
-import tempfile
-from contextlib import contextmanager
 
 from mock import patch
 
@@ -17,31 +14,6 @@ from simphony_mayavi.plugins.engine_manager import EngineManager
 from simphony_mayavi.sources.tests.testing_utils import DummyEngine
 from simphony_mayavi.plugins.tests.testing_utils import press_button_by_label
 from simphony_mayavi.tests.testing_utils import run_and_check_dialog_was_opened
-
-
-# temp_engine should be loaded successfully from this script
-PYTHON_SCRIPT = '''
-from simphony_mayavi.sources.tests import testing_utils
-
-temp_engine = testing_utils.DummyEngine()
-file_path = __file__
-not_an_engine = 1
-'''
-
-# An error would be raised while executing this script
-ERROR_PYTHON_SCRIPT = '''
-from simphony_mayavi.sources.tests import testing_utils
-
-temp_engine = testing_utils.DummyEngine()
-not_an_engine =
-
-'''
-
-# An error would be raised for this script
-# as no instance of ABCModelingEngine is found
-NO_ENGINE_PYTHON_SCRIPT = '''
-not_an_engine = 1
-'''
 
 
 class SimpleEngineFactory(ABCEngineFactory):
@@ -71,92 +43,6 @@ MOCKED_ENGINE_FACTORIES = {"good_factory": SimpleEngineFactory(),
 
 class TestAddEnginePanel(UnittestTools, unittest.TestCase):
 
-    @contextmanager
-    def write_file(self, suffix, content):
-        ''' Yield the path to the temporary file
-
-        Parameters
-        ----------
-        suffix : str
-            suffix of the file
-        content : str
-            content of the file to be written
-        '''
-        # create a python script file
-        file_d, tmp_path = tempfile.mkstemp(suffix=suffix)
-
-        try:
-            # write the sample script
-            with open(tmp_path, "w") as tmpfile:
-                tmpfile.write(content)
-        except IOError:
-            message = "Cannot create temporary script file for testing"
-            raise IOError(message)
-        else:
-            yield tmp_path
-        finally:
-            # remove the temporary file
-            os.remove(tmp_path)
-
-    def test_load_engine_from_file(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-
-        with self.write_file(".py", PYTHON_SCRIPT) as tmp_path:
-            with self.assertMultiTraitChanges([panel],
-                                              ["file_name",
-                                               "loaded_variables_names"], []):
-                panel.file_name = tmp_path
-            with self.assertTraitChanges(panel, "new_engine"):
-                panel.selected_variable_name = "temp_engine"
-
-        # only the local variable that is an instance of
-        # ABCModelingEngine is loaded
-        self.assertIn("temp_engine", panel.loaded_variables_names)
-        self.assertNotIn("not_an_engine", panel.loaded_variables_names)
-
-    def test_error_load_engine_from_error_file(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-
-        def set_file_name():
-            panel.file_name = tmp_path
-            return True
-
-        # for testing modal dialog
-        tester = ModalDialogTester(set_file_name)
-
-        # The content of the script leads to error during ``exec``
-        with self.write_file(".py", ERROR_PYTHON_SCRIPT) as tmp_path:
-            run_and_check_dialog_was_opened(self, tester, True)
-
-    def test_error_load_from_non_py_file(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-
-        def set_file_name():
-            panel.file_name = tmp_path
-            return True
-
-        # for testing modal dialog
-        tester = ModalDialogTester(set_file_name)
-
-        # The file does not end with *.py
-        with self.write_file("", PYTHON_SCRIPT) as tmp_path:
-            run_and_check_dialog_was_opened(self, tester, True)
-
-    def test_error_load_from_py_file_no_engine(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-
-        def set_file_name():
-            panel.file_name = tmp_path
-            return True
-
-        # for testing modal dialog
-        tester = ModalDialogTester(set_file_name)
-
-        # The script contains no local variable that is an instance
-        # of ABCModelingEngine
-        with self.write_file(".py", NO_ENGINE_PYTHON_SCRIPT) as tmp_path:
-            run_and_check_dialog_was_opened(self, tester, True)
-
     @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
            MOCKED_ENGINE_FACTORIES)
     def test_create_from_factory_need_more_definitions(self):
@@ -173,10 +59,6 @@ class TestAddEnginePanel(UnittestTools, unittest.TestCase):
 
         # ensure the new engine is defined
         self.assertIsInstance(panel.new_engine, ABCModelingEngine)
-
-        # ensure the load-from-file panel is reset
-        self.assertEqual(panel.file_name, "")
-        self.assertTrue(len(panel.loaded_variables_names) == 0)
 
     @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
            MOCKED_ENGINE_FACTORIES)
@@ -195,10 +77,6 @@ class TestAddEnginePanel(UnittestTools, unittest.TestCase):
 
         self.assertIsNone(panel.new_engine)
 
-        # ensure the load-from-file panel is reset
-        self.assertEqual(panel.file_name, "")
-        self.assertTrue(len(panel.loaded_variables_names) == 0)
-
     @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
            MOCKED_ENGINE_FACTORIES)
     def test_create_from_factory(self):
@@ -207,30 +85,6 @@ class TestAddEnginePanel(UnittestTools, unittest.TestCase):
         with self.assertTraitChanges(panel, "new_engine"):
             panel.factory_name = "good_factory"
 
-        self.assertIsInstance(panel.new_engine, ABCModelingEngine)
-        self.assertEqual(panel.file_name, "")
-        self.assertTrue(len(panel.loaded_variables_names) == 0)
-
-    @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
-           MOCKED_ENGINE_FACTORIES)
-    def test_factory_section_reset_after_load_from_file(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-        panel.factory_name = "good_factory"
-
-        with self.write_file(".py", PYTHON_SCRIPT) as tmp_path:
-
-            # only defined the file
-            with self.assertTraitDoesNotChange(panel, "factory_name"):
-                panel.file_name = tmp_path
-
-            # now select the local variable loaded
-            with self.assertMultiTraitChanges([panel],
-                                              ["factory_name", "new_engine"],
-                                              []):
-                selected_variable_name = panel.loaded_variables_names[-1]
-                panel.selected_variable_name = selected_variable_name
-
-        # new_engine should be defined
         self.assertIsInstance(panel.new_engine, ABCModelingEngine)
 
     @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
@@ -245,28 +99,6 @@ class TestAddEnginePanel(UnittestTools, unittest.TestCase):
             panel.factory_name = ""
 
         self.assertIs(panel.new_engine, None)
-
-        # The load-from-file section should be reset
-        self.assertEqual(panel.file_name, "")
-        self.assertEqual(len(panel.loaded_variables_names), 0)
-        self.assertEqual(panel.loaded_variables, {})
-        self.assertEqual(panel.selected_variable_name, "")
-
-    @patch("simphony_mayavi.plugins.add_engine_panel.DEFAULT_ENGINE_FACTORIES",
-           MOCKED_ENGINE_FACTORIES)
-    def test_reset_factory_section_when_loaded_from_file(self):
-        panel = AddEnginePanel(engine_manager=EngineManager())
-
-        with self.assertTraitChanges(panel, "new_engine"):
-            panel.factory_name = "good_factory"
-
-        with self.write_file(".py", PYTHON_SCRIPT) as tmp_path:
-            panel.file_name = tmp_path
-            panel.selected_variable_name = panel.loaded_variables_names[-1]
-
-        self.assertIsInstance(panel.new_engine, ABCModelingEngine)
-        # create-from-factory section should be reset
-        self.assertEqual(panel.factory_name, "")
 
     def test_add_engine(self):
         engine_manager = EngineManager()
@@ -284,9 +116,6 @@ class TestAddEnginePanel(UnittestTools, unittest.TestCase):
         # the UI should be reset
         self.assertEqual(panel.new_engine_name, "")
         self.assertIs(panel.new_engine, None)
-        self.assertEqual(panel.loaded_variables, {})
-        self.assertEqual(panel.selected_variable_name, "")
-        self.assertEqual(panel.file_name, "")
         self.assertEqual(panel.factory_name, "")
 
     def test_add_engine_with_duplicated_name(self):

--- a/simphony_mayavi/tests/test_plugin_loading.py
+++ b/simphony_mayavi/tests/test_plugin_loading.py
@@ -7,7 +7,10 @@ PLUGINAPI = [
     'VTKLattice',
     'VTKMesh',
     'adapt2cuds',
-    'load']
+    'load',
+    'get_mayavi2_engine_manager',
+    'add_engine_to_mayavi2'
+]
 
 
 class TestPluginLoading(unittest.TestCase):

--- a/simphony_mayavi/tests/test_plugin_loading.py
+++ b/simphony_mayavi/tests/test_plugin_loading.py
@@ -8,7 +8,6 @@ PLUGINAPI = [
     'VTKMesh',
     'adapt2cuds',
     'load',
-    'get_mayavi2_engine_manager',
     'add_engine_to_mayavi2'
 ]
 


### PR DESCRIPTION
Fix #142 

This assumes that branch `refactor-engine-factory` #130 would be merged.
Likely to cause clashes in `plugin.py` and `api.py` with #134.

Usage:

Save the following into a script and run it within Mayavi2.

```
# do a bunch of stuff setting up a modeling engine
engine = ...

from simphony.visualisation import mayavi_tools
mayavi_tools.add_engine_to_mayavi2("engine_name", engine)
```
