### PR TITLE
Clean snapshot

### DIFF
--- a/simphony_mayavi/snapshot.py
+++ b/simphony_mayavi/snapshot.py
@@ -1,12 +1,6 @@
 import sys
 
 from mayavi import mlab
-try:
-    from vtk import VTK_MAJOR_VERSION, VTK_MINOR_VERSION
-except ImportError:
-    # For VTK version < 5.8.0
-    VTK_MAJOR_VERSION, VTK_MINOR_VERSION = None, None
-
 from contextlib import contextmanager
 
 from simphony.cuds.abc_mesh import ABCMesh
@@ -25,13 +19,8 @@ def get_figure(*args, **kwargs):
 
         # Make sure a new figure is created
         figure = mlab.figure(*args, **kwargs)
-
-        # Seg fault while creating subsequent images
-        # for VTK version 6.3 on Linux
-        # https://github.com/enthought/mayavi/issues/302
-        if (VTK_MAJOR_VERSION, VTK_MINOR_VERSION) != (6, 3):
-            # if offscreen is True, this is set anyway
-            figure.scene.off_screen_rendering = True
+        # if offscreen is True, this is set already
+        figure.scene.off_screen_rendering = True
 
         yield figure
 

--- a/simphony_mayavi/snapshot.py
+++ b/simphony_mayavi/snapshot.py
@@ -1,13 +1,44 @@
 import sys
 
 from mayavi import mlab
-from mayavi.tools.tools import _typical_distance
+try:
+    from vtk import VTK_MAJOR_VERSION, VTK_MINOR_VERSION
+except ImportError:
+    # For VTK version < 5.8.0
+    VTK_MAJOR_VERSION, VTK_MINOR_VERSION = None, None
+
+from contextlib import contextmanager
 
 from simphony.cuds.abc_mesh import ABCMesh
 from simphony.cuds.abc_particles import ABCParticles
 from simphony.cuds.abc_lattice import ABCLattice
 
 from simphony_mayavi.sources.api import CUDSSource
+from simphony_mayavi.modules.default_module import default_module
+
+
+@contextmanager
+def get_figure(*args, **kwargs):
+    try:
+        if sys.platform == "win32":
+            mlab.options.offscreen = True
+
+        # Make sure a new figure is created
+        figure = mlab.figure(*args, **kwargs)
+
+        # Seg fault while creating subsequent images
+        # for VTK version 6.3 on Linux
+        # https://github.com/enthought/mayavi/issues/302
+        if (VTK_MAJOR_VERSION, VTK_MINOR_VERSION) != (6, 3):
+            # if offscreen is True, this is set anyway
+            figure.scene.off_screen_rendering = True
+
+        yield figure
+
+    finally:
+        mlab.options.offscreen = False
+        mlab.clf()
+        mlab.close()
 
 
 def snapshot(cuds, filename):
@@ -23,36 +54,24 @@ def snapshot(cuds, filename):
          The filename to use for the output file.
 
     """
+    # adapt to CUDSSource
+    if isinstance(cuds, (ABCMesh, ABCParticles, ABCLattice)):
+        source = CUDSSource(cuds=cuds)
+    else:
+        msg = 'Provided object {} is not of any known cuds type'
+        raise TypeError(msg.format(type(cuds)))
+
+    # set image size
     size = 800, 600
 
-    if sys.platform == 'win32':
-        mlab.options.offscreen = True
-    else:
-        figure = mlab.gcf()
-        figure.scene.off_screen_rendering = True
+    with get_figure(size=size):
+        # add source
+        mlab.pipeline.add_dataset(source)
 
-    try:
-        if isinstance(cuds, ABCMesh):
-            source = CUDSSource(cuds=cuds)
-            mlab.pipeline.surface(source, name=cuds.name)
-        elif isinstance(cuds, ABCParticles):
-            source = CUDSSource(cuds=cuds)
-            scale_factor = _typical_distance(source.data) * 0.5
-            mlab.pipeline.glyph(
-                source, name=cuds.name,
-                scale_factor=scale_factor, scale_mode='none')
-            surface = mlab.pipeline.surface(source)
-            surface.actor.mapper.scalar_visibility = False
-        elif isinstance(cuds, ABCLattice):
-            source = CUDSSource(cuds=cuds)
-            scale_factor = _typical_distance(source.data) * 0.5
-            mlab.pipeline.glyph(
-                source, name=cuds.name,
-                scale_factor=scale_factor, scale_mode='none')
-        else:
-            msg = 'Provided object {} is not of any known cuds type'
-            raise TypeError(msg.format(type(cuds)))
-        mlab.savefig(filename, size, magnification=1.0)
-    finally:
-        mlab.clf()
-        mlab.close()
+        modules = default_module(source)
+
+        # add default modules
+        for module in modules:
+            source.add_module(module)
+
+        mlab.savefig(filename, size=size)

--- a/simphony_mayavi/tests/test_snapshot.py
+++ b/simphony_mayavi/tests/test_snapshot.py
@@ -6,7 +6,6 @@ import shutil
 import numpy
 from PIL import Image
 
-
 from simphony_mayavi.snapshot import snapshot
 from simphony.cuds.lattice import make_cubic_lattice
 from simphony.cuds.mesh import Mesh, Point
@@ -66,6 +65,7 @@ class TestSnapShot(unittest.TestCase):
         image = numpy.array(Image.open(filename))
 
         self.assertEqual(image.shape[:2], (600, 800))
+
         if image.shape[2] == 3:
             check = numpy.sum(image == [0, 0, 0], axis=2) == 3
         elif image.shape[2] == 4:

--- a/simphony_mayavi/tests/test_snapshot.py
+++ b/simphony_mayavi/tests/test_snapshot.py
@@ -22,6 +22,10 @@ class TestSnapShot(unittest.TestCase):
     def cleanup(self):
         shutil.rmtree(self.temp_dir)
 
+    def test_error_unknown_cuds(self):
+        with self.assertRaises(TypeError):
+            snapshot((1, 2, 3), self.filename)
+
     def test_lattice_snapshot(self):
         filename = self.filename
         lattice = make_cubic_lattice(


### PR DESCRIPTION
- Ensure that offscreen is set back to False after calling snapshot function
- Ensure a new scene is created for each snapshot
- work around for "off_screen_rendering causing seg fault on creating the second/third/... figure for VTK 6.3"
- Make pipeline's modules consistent with `show`

Based on the `clean-show` branch.
