### PR TITLE
Overload CUDSSource init for user-friendliness

### DIFF
--- a/simphony_mayavi/plugins/add_source_panel.py
+++ b/simphony_mayavi/plugins/add_source_panel.py
@@ -118,8 +118,8 @@ class AddSourcePanel(HasTraits):
             message_dialog.error("The engine has no dataset")
             return
 
-        source = EngineSource(engine=self.engine,
-                              engine_name=self.engine_name)
+        source = EngineSource(engine=self.engine)
+        source.engine_name = self.engine_name
         source._dataset_changed()
 
         # Default trait view of EngineSource

--- a/simphony_mayavi/sources/cuds_file_source.py
+++ b/simphony_mayavi/sources/cuds_file_source.py
@@ -46,7 +46,7 @@ class CUDSFileSource(CUDSSource):
 
     # Public interface #####################################################
 
-    def __init__(self):
+    def __init__(self, **traits):
         """ Create a CUDSFileSource instance
 
         Example
@@ -59,7 +59,7 @@ class CUDSFileSource(CUDSSource):
         # This function overloads CUDSSource.__init__
 
         # required by Traits:
-        HasTraits.__init__(self)
+        super(CUDSFileSource, self).__init__(**traits)
 
     def initialize(self, filename):
         """ Initialise the CUDS file source.

--- a/simphony_mayavi/sources/cuds_file_source.py
+++ b/simphony_mayavi/sources/cuds_file_source.py
@@ -1,7 +1,7 @@
 from contextlib import closing
 import logging
 
-from traits.api import ListStr, Instance, Bool, TraitError
+from traits.api import ListStr, Instance, Bool, TraitError, HasTraits
 from traitsui.api import View, Group, Item, VGroup
 from apptools.persistence.file_path import FilePath
 from apptools.persistence.state_pickler import set_state
@@ -45,6 +45,21 @@ class CUDSFileSource(CUDSSource):
                 Item(name='data'))))
 
     # Public interface #####################################################
+
+    def __init__(self):
+        """ Create a CUDSFileSource instance
+
+        Example
+        -------
+        source = CUDSFileSource()
+        source.initialize("path/to/cuds_file.cuds")
+        """
+        # This __init__ function should take no argument in order
+        # for it to be used by Mayavi2 application
+        # This function overloads CUDSSource.__init__
+
+        # required by Traits:
+        HasTraits.__init__(self)
 
     def initialize(self, filename):
         """ Initialise the CUDS file source.

--- a/simphony_mayavi/sources/cuds_source.py
+++ b/simphony_mayavi/sources/cuds_source.py
@@ -1,6 +1,6 @@
 import logging
 
-from traits.api import Either, Instance, TraitError, Property
+from traits.api import Either, Instance, TraitError, Property, HasTraits
 from traitsui.api import View, Group, Item
 from mayavi.core.api import PipelineInfo
 from mayavi.sources.vtk_data_source import VTKDataSource
@@ -89,6 +89,42 @@ class CUDSSource(VTKDataSource):
 
     # Public method ########################################################
 
+    def __init__(self, cuds=None, point_scalars=None, point_vectors=None,
+                 cell_scalars=None, cell_vectors=None):
+        """Initialise the CUDSSource
+
+        Parameters
+        ----------
+        cuds : ABCParticles, ABCLattice, ABCMesh or H5Mesh, optional
+
+        point_scalars : str, optional
+            CUBA name of the data to be selected as point scalars.
+            Default is the first available point scalars.
+
+        point_vectors : str, optional
+            CUBA name of the data to be selected as point vectors.
+            Default is the first available point vectors.
+
+        cell_scalars : str, optional
+            CUBA name of the data to be selected as cell scalars.
+            Default is the first available cell scalars.
+
+        cell_scalars : str, optional
+            CUBA name of the data to be selected as cell scalars.
+            Default is the first available cell scalars.
+        """
+        # required by Traits
+        HasTraits.__init__(self)
+
+        if cuds:
+            self.cuds = cuds
+
+        # if cuds is not defined, VTKDataSource will complain
+        self._select_attributes(point_scalars=point_scalars,
+                                point_vectors=point_vectors,
+                                cell_scalars=cell_scalars,
+                                cell_vectors=cell_vectors)
+
     def update(self):
         """ Recalculate the VTK data from the CUDS dataset
         Useful when ``cuds`` is modified after assignment
@@ -96,6 +132,26 @@ class CUDSSource(VTKDataSource):
         self._set_vtk_cuds(self.cuds)
 
     # Private interface ####################################################
+
+    def _select_attributes(self, point_scalars=None, point_vectors=None,
+                           cell_scalars=None, cell_vectors=None):
+        """ Select point_scalars/point_vectors/cell_scalars/cell_vectors
+        for the CUDSSource
+
+        If point_scalars/... is undefined, the first available attribute
+        is selected by mayavi.core.trait_defs.DEnum (see VTKDataSource)
+        """
+        if point_scalars is not None:
+            self.point_scalars_name = point_scalars
+
+        if point_vectors is not None:
+            self.point_vectors_name = point_vectors
+
+        if cell_scalars is not None:
+            self.cell_scalars_name = cell_scalars
+
+        if cell_vectors is not None:
+            self.cell_vectors_name = cell_vectors
 
     def _get_name(self):
         """ Returns the name to display on the tree view.  Note that

--- a/simphony_mayavi/sources/cuds_source.py
+++ b/simphony_mayavi/sources/cuds_source.py
@@ -90,7 +90,7 @@ class CUDSSource(VTKDataSource):
     # Public method ########################################################
 
     def __init__(self, cuds=None, point_scalars=None, point_vectors=None,
-                 cell_scalars=None, cell_vectors=None):
+                 cell_scalars=None, cell_vectors=None, **traits):
         """Initialise the CUDSSource
 
         Parameters
@@ -112,9 +112,11 @@ class CUDSSource(VTKDataSource):
         cell_scalars : str, optional
             CUBA name of the data to be selected as cell scalars.
             Default is the first available cell scalars.
+
+        Other optional keyword parameters are parsed to VTKDataSource
         """
         # required by Traits
-        HasTraits.__init__(self)
+        super(CUDSSource, self).__init__(**traits)
 
         if cuds:
             self.cuds = cuds

--- a/simphony_mayavi/sources/cuds_source.py
+++ b/simphony_mayavi/sources/cuds_source.py
@@ -141,16 +141,16 @@ class CUDSSource(VTKDataSource):
         If point_scalars/... is undefined, the first available attribute
         is selected by mayavi.core.trait_defs.DEnum (see VTKDataSource)
         """
-        if point_scalars is not None:
+        if self._point_scalars_list and point_scalars is not None:
             self.point_scalars_name = point_scalars
 
-        if point_vectors is not None:
+        if self._point_vectors_list and point_vectors is not None:
             self.point_vectors_name = point_vectors
 
-        if cell_scalars is not None:
+        if self._cell_scalars_list and cell_scalars is not None:
             self.cell_scalars_name = cell_scalars
 
-        if cell_vectors is not None:
+        if self._cell_vectors_list and cell_vectors is not None:
             self.cell_vectors_name = cell_vectors
 
     def _get_name(self):

--- a/simphony_mayavi/sources/cuds_source.py
+++ b/simphony_mayavi/sources/cuds_source.py
@@ -121,7 +121,8 @@ class CUDSSource(VTKDataSource):
         if cuds:
             self.cuds = cuds
 
-        # if cuds is not defined, VTKDataSource will complain
+        # if cuds is not defined, _point_scalars_list (etc.) is empty
+        # nothing would be selected
         self._select_attributes(point_scalars=point_scalars,
                                 point_vectors=point_vectors,
                                 cell_scalars=cell_scalars,

--- a/simphony_mayavi/sources/engine_source.py
+++ b/simphony_mayavi/sources/engine_source.py
@@ -1,6 +1,7 @@
 import logging
 
-from traits.api import Instance, Enum, Str, ListStr, cached_property, Property
+from traits.api import (HasTraits, Instance, Enum, Str, ListStr,
+                        cached_property, Property)
 from traitsui.api import View, Group, Item, VGroup
 from apptools.persistence.state_pickler import set_state
 
@@ -69,6 +70,59 @@ class EngineSource(CUDSSource):
         return self.engine.get_dataset_names()
 
     # Public interface #####################################################
+
+    def __init__(self, engine=None, dataset=None,
+                 point_scalars=None, point_vectors=None,
+                 cell_scalars=None, cell_vectors=None):
+        """Initialise the EngineSource
+
+        Parameters
+        ----------
+        engine : ABCModelingEngine, optional
+           The SimPhoNy Modeling Engine where dataset is loaded from.
+           Default is None.
+
+        dataset : str, optional
+            Name of the dataset to be extracted from engine.
+            Default is the first available dataset if engine is defined,
+            otherwise it is an empty string
+
+        point_scalars : str, optional
+            CUBA name of the data to be selected as point scalars.
+            Default is the first available point scalars.
+
+        point_vectors : str, optional
+            CUBA name of the data to be selected as point vectors.
+            Default is the first available point vectors.
+
+        cell_scalars : str, optional
+            CUBA name of the data to be selected as cell scalars.
+            Default is the first available cell scalars.
+
+        cell_scalars : str, optional
+            CUBA name of the data to be selected as cell scalars.
+            Default is the first available cell scalars.
+        """
+        # required by Traits
+        HasTraits.__init__(self)
+
+        self.engine = engine
+
+        # if dataset is not defined, default is already set by DEnum
+        if dataset:
+            self.dataset = dataset
+
+        if any((point_scalars, point_vectors, cell_scalars, cell_vectors)):
+            # the vtk_data may not be loaded for performance purpose
+            # however if point_scalars/... is defined that means the
+            # user wants to load the vtk data, so we load it here
+            if self._cuds is None:
+                self._update_cuds()
+
+            self._select_attributes(point_scalars=point_scalars,
+                                    point_vectors=point_vectors,
+                                    cell_scalars=cell_scalars,
+                                    cell_vectors=cell_vectors)
 
     def start(self):
         """ Load dataset from the engine and start the visualisation """

--- a/simphony_mayavi/sources/engine_source.py
+++ b/simphony_mayavi/sources/engine_source.py
@@ -73,7 +73,7 @@ class EngineSource(CUDSSource):
 
     def __init__(self, engine=None, dataset=None,
                  point_scalars=None, point_vectors=None,
-                 cell_scalars=None, cell_vectors=None):
+                 cell_scalars=None, cell_vectors=None, **traits):
         """Initialise the EngineSource
 
         Parameters
@@ -102,9 +102,11 @@ class EngineSource(CUDSSource):
         cell_scalars : str, optional
             CUBA name of the data to be selected as cell scalars.
             Default is the first available cell scalars.
+
+        Other optional keyword parameters are parsed to CUDSSource
         """
         # required by Traits
-        HasTraits.__init__(self)
+        super(EngineSource, self).__init__(**traits)
 
         self.engine = engine
 

--- a/simphony_mayavi/sources/tests/test_cuds_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_source.py
@@ -227,15 +227,18 @@ class TestMeshSource(unittest.TestCase):
         self.assertIs(source.data, vtk_container.data_set)
         self.assertIs(vtk_cuds, vtk_container)
 
-    def test_mesh_source_name(self):
-        # given
-        mesh = Mesh('my_mesh')
-
+    def test_mesh_source_name_and_set_data_attributes(self):
         # when
-        source = CUDSSource(cuds=mesh)
+        # all data attributes are turned off except for point_scalars
+        source = CUDSSource(cuds=self.container,
+                            point_scalars="TEMPERATURE", point_vectors="",
+                            cell_scalars="", cell_vectors="")
 
         # then
-        self.assertEqual(source.name, 'my_mesh (CUDS Mesh)')
+        self.assertEqual(source.point_scalars_name, "TEMPERATURE")
+        self.assertEqual(source.point_vectors_name, "")
+        self.assertEqual(source.cell_scalars_name, "")
+        self.assertEqual(source.cell_vectors_name, "")
 
 
 class TestLatticeSource(unittest.TestCase):

--- a/simphony_mayavi/sources/tests/test_cuds_source.py
+++ b/simphony_mayavi/sources/tests/test_cuds_source.py
@@ -42,7 +42,10 @@ class TestMeshSource(unittest.TestCase):
         self.edges = [[1, 4], [3, 8]]
         self.container = container = Mesh('test')
         point_iter = (Point(coordinates=point,
-                            data=DataContainer(TEMPERATURE=index))
+                            data=DataContainer(TEMPERATURE=index,
+                                               MASS=index,
+                                               VELOCITY=(index, 0., 0.),
+                                               FORCE=(index, 0., 0.)))
                       for index, point in enumerate(points))
         self.point_uids = container.add_points(point_iter)
 
@@ -60,7 +63,7 @@ class TestMeshSource(unittest.TestCase):
         points = source.data.points.to_array()
         self.assertEqual(len(points), number_of_points)
         self.assertEqual(len(vtk_cuds.point2index), number_of_points)
-        self.assertEqual(vtk_dataset.point_data.number_of_arrays, 1)
+        self.assertEqual(vtk_dataset.point_data.number_of_arrays, 4)
         temperature = vtk_dataset.point_data.get_array('TEMPERATURE')
         for key, index in vtk_cuds.point2index.iteritems():
             point = container.get_point(key)
@@ -190,7 +193,7 @@ class TestMeshSource(unittest.TestCase):
             len(self.faces) + len(self.edges) + len(self.cells)
         self.assertEqual(len(elements), number_of_elements)
         self.assertEqual(len(vtk_cuds.element2index), number_of_elements)
-        self.assertEqual(source.data.point_data.number_of_arrays, 1)
+        self.assertEqual(source.data.point_data.number_of_arrays, 4)
         self.assertEqual(source.data.cell_data.number_of_arrays, 1)
         temperature = source.data.cell_data.get_array('TEMPERATURE')
         for key, index in vtk_cuds.element2index.iteritems():
@@ -227,7 +230,7 @@ class TestMeshSource(unittest.TestCase):
         self.assertIs(source.data, vtk_container.data_set)
         self.assertIs(vtk_cuds, vtk_container)
 
-    def test_mesh_source_name_and_set_data_attributes(self):
+    def test_mesh_source_and_set_point_scalars(self):
         # when
         # all data attributes are turned off except for point_scalars
         source = CUDSSource(cuds=self.container,
@@ -239,6 +242,18 @@ class TestMeshSource(unittest.TestCase):
         self.assertEqual(source.point_vectors_name, "")
         self.assertEqual(source.cell_scalars_name, "")
         self.assertEqual(source.cell_vectors_name, "")
+
+    def test_mesh_source_and_set_point_vectors_default_point_scalars(self):
+        # when
+        # only define point_vectors
+        source = CUDSSource(cuds=self.container, point_vectors="VELOCITY")
+
+        # then
+        # this is defined
+        self.assertEqual(source.point_vectors_name, "VELOCITY")
+
+        # this is assumed (first available)
+        self.assertIn(source.point_scalars_name, ("TEMPERATURE", "MASS"))
 
 
 class TestLatticeSource(unittest.TestCase):

--- a/simphony_mayavi/sources/tests/test_engine_source.py
+++ b/simphony_mayavi/sources/tests/test_engine_source.py
@@ -59,6 +59,53 @@ class TestEngineSource(unittest.TestCase, UnittestTools):
         self.assertIs(source._cuds, None)
         self.assertIs(source._vtk_cuds, None)
 
+    def test_init_with_engine_and_dataset(self):
+        """ Test if engine and dataset can be defined on init.
+        Since the dataset is defined, vtk_data should be loaded
+        """
+        # when
+        source = EngineSource(engine=self.engine, dataset="lattice")
+
+        # then
+        self.assertEqual(source.engine, self.engine)
+        self.assertEqual(source.dataset, "lattice")
+        self.assertIsInstance(source._cuds, Lattice)
+        self.assertIsInstance(source._vtk_cuds, VTKLattice)
+
+    def test_init_with_engine_and_data_attributes(self):
+        """ Test if engine, point_scalars can be defined on init.
+        Note that dataset is assumed to be the first available
+        """
+        # when
+        source = EngineSource(engine=self.engine,
+                              point_scalars="TEMPERATURE")
+
+        # then
+        self.assertEqual(source.engine, self.engine)
+        self.assertIn(source.dataset, self.datasets)
+        self.assertEqual(source.point_scalars_name, "TEMPERATURE")
+
+    def test_init_with_engine_and_dataset_and_data_attributes(self):
+        """ Test if engine, dataset and data attributes can be defined on init.
+        """
+        # when
+        source = EngineSource(engine=self.engine, dataset="mesh",
+                              cell_scalars="TEMPERATURE",
+                              cell_vectors="VELOCITY")
+
+        # then
+        self.assertEqual(source.engine, self.engine)
+        self.assertEqual(source.dataset, "mesh")
+        self.assertIsInstance(source._cuds, Mesh)
+        self.assertIsInstance(source._vtk_cuds, VTKMesh)
+
+        # These are the one defined
+        self.assertEqual(source.cell_scalars_name, "TEMPERATURE")
+        self.assertEqual(source.cell_vectors_name, "VELOCITY")
+
+        # This is assumed (i.e. first available)
+        self.assertEqual(source.point_scalars_name, "TEMPERATURE")
+
     def test_source_name(self):
         # given
         source = EngineSource(engine=self.engine)


### PR DESCRIPTION
So that the user doesn't have to learn much Traits in order to use CUDSSource etc.

If this is good then #162 can be implemented differently:

```
def show(cuds, **kwargs):
...
source = CUDSSource(cuds=cuds, **kwargs)
...
```
