### PR TITLE
Fix test failure with a different random seed

### DIFF
--- a/simphony_mayavi/sources/tests/test_engine_source.py
+++ b/simphony_mayavi/sources/tests/test_engine_source.py
@@ -135,9 +135,14 @@ class TestEngineSource(unittest.TestCase, UnittestTools):
         # When the source is added to an engine it should load the dataset.
         with self.assertTraitChanges(source, 'data_changed'):
             engine.add_source(source)
-        self.assertIsInstance(source.cuds, Particles)
-        self.assertIsInstance(source._vtk_cuds, VTKParticles)
-        self.assertIsInstance(source.outputs[0], tvtk.PolyData)
+
+        self.assertIsInstance(source.cuds, (Lattice, Particles, Mesh))
+        self.assertIsInstance(source._vtk_cuds, (VTKLattice,
+                                                 VTKParticles,
+                                                 VTKMesh))
+        self.assertIsInstance(source.outputs[0], (tvtk.ImageData,
+                                                  tvtk.PolyData,
+                                                  tvtk.UnstructuredGrid))
 
     def test_save_load_visualization(self):
         # set up the visualization


### PR DESCRIPTION
There are a number of datasets in the `simphony.ABCModelingEngine` in the tests for EngineSource.  The first available dataset may be different depending on the random seed.  This fixes the test for testing if ONE dataset is loaded upon `mayavi_engine.add_source`.
