### PR TITLE
Adds required conversion to int for VTK extracted data.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ envisage==4.5.1
 # Pinned in response to failing test. 
 # See https://github.com/simphony/simphony-mayavi/pull/173
 mayavi==4.4.4
+numpy>=1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ envisage==4.5.1
 # Pinned in response to failing test. 
 # See https://github.com/simphony/simphony-mayavi/pull/173
 mayavi==4.4.4
-numpy>=1.12

--- a/simphony_mayavi/core/cell_collection.py
+++ b/simphony_mayavi/core/cell_collection.py
@@ -59,6 +59,7 @@ class CellCollection(MutableSequence):
         start = location + 1
         data = cells.data
         npoints = data[location]
+        print data, npoints
         if npoints == len(value):
             for i, j in enumerate(value):
                 data[start + i] = j

--- a/simphony_mayavi/core/cell_collection.py
+++ b/simphony_mayavi/core/cell_collection.py
@@ -58,8 +58,7 @@ class CellCollection(MutableSequence):
         location = self._cell_location(index)
         start = location + 1
         data = cells.data
-        npoints = data[location]
-        print data, npoints
+        npoints = int(data[location])
         if npoints == len(value):
             for i, j in enumerate(value):
                 data[start + i] = j
@@ -86,7 +85,7 @@ class CellCollection(MutableSequence):
         cells = self._cell_array
         new_length = len(self) - 1
         start = location + 1
-        npoints = cells.data[location]
+        npoints = int(cells.data[location])
         array = cells.to_array()
         left, _, right = numpy.split(
             array, [location, start + npoints])


### PR DESCRIPTION
The floating point value extracted works ok with numpy 1.9, but not with numpy 1.12, where it throws an exception. The conversion is done on other parts of the code as well, so it is really missing