### PR TITLE
Backport #198: Fix missing conversion to int for vtk extracted data.

### DIFF
--- a/simphony_mayavi/core/cell_collection.py
+++ b/simphony_mayavi/core/cell_collection.py
@@ -58,7 +58,7 @@ class CellCollection(MutableSequence):
         location = self._cell_location(index)
         start = location + 1
         data = cells.data
-        npoints = data[location]
+        npoints = int(data[location])
         if npoints == len(value):
             for i, j in enumerate(value):
                 data[start + i] = j
@@ -85,7 +85,7 @@ class CellCollection(MutableSequence):
         cells = self._cell_array
         new_length = len(self) - 1
         start = location + 1
-        npoints = cells.data[location]
+        npoints = int(cells.data[location])
         array = cells.to_array()
         left, _, right = numpy.split(
             array, [location, start + npoints])


### PR DESCRIPTION
Adds required conversion to int for VTK extracted data.
(cherry picked from commit b7a02b2fd1caa1cc972d4758bc782faaba7b1447)